### PR TITLE
PEZY-221: Configure .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ temp/
 # Secrets (never commit these)
 *.pem
 *.key
-secrets.json
+


### PR DESCRIPTION
## Description
    Configure .gitignore

    ## Jira Reference
    - Issue: [PEZY-221](https://oshadadilshan.atlassian.net//browse/PEZY-221)

    ## Description from Jira
    Exclude node_modules, env files, coverage reports, and build artifacts.

[PEZY-221]: https://oshadadilshan.atlassian.net/browse/PEZY-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ