### PR TITLE
PEZY-469: Implement license number field validation

### DIFF
--- a/frontend/src/pages/FinePay.css
+++ b/frontend/src/pages/FinePay.css
@@ -75,10 +75,26 @@
   border-color: #0ea5e9;
 }
 
+.fine-pay-card__form input.is-invalid {
+  border-color: #dc2626;
+  background: #fef2f2;
+}
+
+.fine-pay-card__form input.is-invalid:focus {
+  outline-color: #f87171;
+  border-color: #dc2626;
+}
+
 .fine-pay-card__form small {
   color: #64748b;
   font-size: 0.72rem;
   margin-top: 0.15rem;
+}
+
+.fine-pay-card__error {
+  color: #b91c1c;
+  font-size: 0.74rem;
+  font-weight: 600;
 }
 
 .fine-pay-card__form button {

--- a/frontend/src/pages/FinePay.tsx
+++ b/frontend/src/pages/FinePay.tsx
@@ -19,7 +19,30 @@ const primaryMenu: { label: string; path?: string }[] = [
 
 export default function FinePay() {
   const [menuOpen, setMenuOpen] = useState(false)
+  const [licenseNumber, setLicenseNumber] = useState('')
+  const [licenseError, setLicenseError] = useState('')
   const navigate = useNavigate()
+
+  // Common Sri Lankan license formats supported by the portal.
+  const sriLankanLicensePatterns = [
+    /^[A-Z]\d{7}$/, // Example: B1234567
+    /^[A-Z]{2}\d{6}$/, // Example: AB123456
+    /^[A-Z]{2}\d{7}$/, // Example: AB1234567
+  ]
+
+  const validateLicenseNumber = (value: string): string => {
+    const normalized = value.trim().toUpperCase()
+
+    if (!normalized) {
+      return 'Driving license number is required.'
+    }
+
+    if (!sriLankanLicensePatterns.some(pattern => pattern.test(normalized))) {
+      return 'Enter a valid Sri Lankan license number (e.g. B1234567 or AB123456).'
+    }
+
+    return ''
+  }
 
   const toggleMenu = () => {
     setMenuOpen(previous => !previous)
@@ -27,6 +50,31 @@ export default function FinePay() {
 
   const closeMenu = () => {
     setMenuOpen(false)
+  }
+
+  const handleLicenseChange = (value: string) => {
+    const sanitized = value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 9)
+    setLicenseNumber(sanitized)
+
+    if (licenseError) {
+      setLicenseError(validateLicenseNumber(sanitized))
+    }
+  }
+
+  const handleLicenseBlur = () => {
+    setLicenseError(validateLicenseNumber(licenseNumber))
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const validationError = validateLicenseNumber(licenseNumber)
+
+    if (validationError) {
+      setLicenseError(validationError)
+      return
+    }
+
+    setLicenseError('')
   }
 
   return (
@@ -86,10 +134,28 @@ export default function FinePay() {
           <h2 id="fine-pay-title">Pay Traffic Fines Instantly</h2>
           <p>Enter your driving license number to verify details and settle outstanding fines securely.</p>
 
-          <form className="fine-pay-card__form" onSubmit={event => event.preventDefault()}>
+          <form className="fine-pay-card__form" onSubmit={handleSubmit} noValidate>
             <label htmlFor="license-number">Driving License Number</label>
-            <input id="license-number" name="licenseNumber" type="text" placeholder="E.g. B1234567" autoComplete="off" />
-            <small>Your details are retrieved from the central department database.</small>
+            <input
+              id="license-number"
+              name="licenseNumber"
+              type="text"
+              placeholder="E.g. B1234567 / AB123456"
+              autoComplete="off"
+              maxLength={9}
+              value={licenseNumber}
+              onChange={event => handleLicenseChange(event.target.value)}
+              onBlur={handleLicenseBlur}
+              aria-invalid={Boolean(licenseError)}
+              aria-describedby="license-help license-error"
+              className={licenseError ? 'is-invalid' : ''}
+            />
+            <small id="license-help">Use your Sri Lankan driving license number as printed on the card.</small>
+            {licenseError && (
+              <small id="license-error" className="fine-pay-card__error" role="alert">
+                {licenseError}
+              </small>
+            )}
             <button type="submit">Check Fines</button>
           </form>
         </section>


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Implemented validation for the license number field to ensure it is not empty and matches common Sri Lankan license formats. The validation checks for specific patterns and displays a red error text below the input field if the input is invalid. This feature enhances the overall user experience by providing instant feedback on invalid inputs.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-469](https://oshadadilshan.atlassian.net/browse/PEZY-469)

## Changes
- Added CSS classes for invalid input fields and error messages
- Implemented the `validateLicenseNumber` function to check for valid Sri Lankan license numbers
- Added event handlers for input change and blur events to handle validation and error display
- Updated the form submission handler to prevent submission if the license number is invalid

[PEZY-469]: https://oshadadilshan.atlassian.net/browse/PEZY-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ