### PR TITLE
PEZY-497: Admin Dashboard Stat Cards

### DIFF
--- a/frontend/src/components/admin/AdminStatCards.css
+++ b/frontend/src/components/admin/AdminStatCards.css
@@ -1,0 +1,100 @@
+.admin-dashboard__stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.admin-dashboard__stat-card {
+  background: #ffffff;
+  border: 1px solid #d6dde7;
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+
+.admin-dashboard__stat-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.admin-dashboard__stat-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  display: inline-grid;
+  place-items: center;
+}
+
+.admin-dashboard__stat-icon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.admin-dashboard__stat-icon.is-blue {
+  background: #e2ecff;
+  color: #2f6de1;
+}
+
+.admin-dashboard__stat-icon.is-red {
+  background: #ffe5e8;
+  color: #df4d5a;
+}
+
+.admin-dashboard__stat-icon.is-yellow {
+  background: #fff1cc;
+  color: #b18700;
+}
+
+.admin-dashboard__stat-icon.is-green {
+  background: #ddf7e8;
+  color: #1ea95a;
+}
+
+.admin-dashboard__stat-trend {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.admin-dashboard__stat-trend.is-positive {
+  background: #dff0e6;
+  color: #17914b;
+}
+
+.admin-dashboard__stat-trend.is-negative {
+  background: #f0efe7;
+  color: #4b5563;
+}
+
+.admin-dashboard__stat-title {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.admin-dashboard__stat-value {
+  margin: 2px 0 0;
+  color: #2f3642;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+
+@media (max-width: 1200px) {
+  .admin-dashboard__stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .admin-dashboard__stats-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/admin/AdminStatCards.tsx
+++ b/frontend/src/components/admin/AdminStatCards.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react'
+import './AdminStatCards.css'
+
+interface StatCard {
+  title: string
+  value: string
+  trend: string
+  trendPositive: boolean
+  tone: 'blue' | 'red' | 'yellow' | 'green'
+  icon: ReactNode
+}
+
+const statCards: StatCard[] = [
+  {
+    title: 'Total Fines',
+    value: '1,247',
+    trend: '+12.5%',
+    trendPositive: true,
+    tone: 'blue',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M5 19h14v2H5v-2Zm1-2h2V9H6v8Zm5 0h2V5h-2v12Zm5 0h2v-6h-2v6Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Criminal Records',
+    value: '856',
+    trend: '+8.2%',
+    trendPositive: true,
+    tone: 'red',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M9 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm6 1a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0 2c-1.8 0-3.3.8-4.2 2.1A5.6 5.6 0 0 0 5 21h2a3.6 3.6 0 0 1 3.5-3h2c1.7 0 3.1.7 4.1 2H19a4 4 0 0 0-4-6ZM9 13a6 6 0 0 0-6 6h2a4 4 0 0 1 4-4h1.2a6.2 6.2 0 0 1 2.6-2H9Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Active Cases',
+    value: '342',
+    trend: '-4.1%',
+    trendPositive: false,
+    tone: 'yellow',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M6 3h9l5 5v13H6V3Zm2 2v14h10V9h-4V5H8Zm2 6h6v2h-6v-2Zm0 4h6v2h-6v-2Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    title: 'News Published',
+    value: '47',
+    trend: '+5.3%',
+    trendPositive: true,
+    tone: 'green',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M4 4h14v14H4V4Zm2 2v10h10V6H6Zm2 2h6v2H8V8Zm0 4h6v2H8v-2Zm11-4h1v8a2 2 0 0 1-2 2h-1v-2h1V8Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+]
+
+export default function AdminStatCards() {
+  return (
+    <section className="admin-dashboard__stats-grid" aria-label="Summary statistics">
+      {statCards.map(card => (
+        <article key={card.title} className="admin-dashboard__stat-card">
+          <div className="admin-dashboard__stat-top">
+            <span className={`admin-dashboard__stat-icon is-${card.tone}`}>{card.icon}</span>
+            <span
+              className={`admin-dashboard__stat-trend${
+                card.trendPositive ? ' is-positive' : ' is-negative'
+              }`}
+            >
+              {card.trend}
+            </span>
+          </div>
+          <p className="admin-dashboard__stat-title">{card.title}</p>
+          <p className="admin-dashboard__stat-value">{card.value}</p>
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/pages/AdminDashboard.css
+++ b/frontend/src/pages/AdminDashboard.css
@@ -1,92 +1,3 @@
-.admin-dashboard__stats-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 18px;
-}
-
-.admin-dashboard__stat-card {
-  background: #ffffff;
-  border: 1px solid #d6dde7;
-  border-radius: 10px;
-  padding: 14px 16px;
-}
-
-.admin-dashboard__stat-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.admin-dashboard__stat-icon {
-  width: 44px;
-  height: 44px;
-  border-radius: 10px;
-  display: inline-grid;
-  place-items: center;
-}
-
-.admin-dashboard__stat-icon svg {
-  width: 22px;
-  height: 22px;
-}
-
-.admin-dashboard__stat-icon.is-blue {
-  background: #e2ecff;
-  color: #2f6de1;
-}
-
-.admin-dashboard__stat-icon.is-red {
-  background: #ffe5e8;
-  color: #df4d5a;
-}
-
-.admin-dashboard__stat-icon.is-yellow {
-  background: #fff1cc;
-  color: #b18700;
-}
-
-.admin-dashboard__stat-icon.is-green {
-  background: #ddf7e8;
-  color: #1ea95a;
-}
-
-.admin-dashboard__stat-trend {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 68px;
-  height: 28px;
-  padding: 0 10px;
-  border-radius: 999px;
-  font-size: 0.9rem;
-  font-weight: 600;
-}
-
-.admin-dashboard__stat-trend.is-positive {
-  background: #dff0e6;
-  color: #17914b;
-}
-
-.admin-dashboard__stat-trend.is-negative {
-  background: #f0efe7;
-  color: #4b5563;
-}
-
-.admin-dashboard__stat-title {
-  margin: 0;
-  color: #6b7280;
-  font-size: 0.95rem;
-}
-
-.admin-dashboard__stat-value {
-  margin: 2px 0 0;
-  color: #2f3642;
-  font-size: 2rem;
-  font-weight: 700;
-  line-height: 1.15;
-}
-
 .admin-dashboard__panel-title {
   margin: 0 0 14px;
   color: #2f3642;
@@ -212,17 +123,7 @@
   color: #1f9a52;
 }
 
-@media (max-width: 1200px) {
-  .admin-dashboard__stats-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 760px) {
-  .admin-dashboard__stats-grid {
-    grid-template-columns: 1fr;
-  }
-
   .admin-dashboard__panel-title {
     font-size: 1.45rem;
   }

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,18 +1,10 @@
 import type { ReactNode } from 'react'
 import AdminMainContent from '../layouts/AdminMainContent'
+import AdminStatCards from '../components/admin/AdminStatCards'
 import './AdminDashboard.css'
 
 interface AdminDashboardProps {
   sectionName?: string
-}
-
-interface StatCard {
-  title: string
-  value: string
-  trend: string
-  trendPositive: boolean
-  tone: 'blue' | 'red' | 'yellow' | 'green'
-  icon: ReactNode
 }
 
 interface ActivityItem {
@@ -27,57 +19,6 @@ interface QuickStat {
   value: string
   tone: 'blue' | 'red' | 'yellow' | 'green'
 }
-
-const statCards: StatCard[] = [
-  {
-    title: 'Total Fines',
-    value: '1,247',
-    trend: '+12.5%',
-    trendPositive: true,
-    tone: 'blue',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M5 19h14v2H5v-2Zm1-2h2V9H6v8Zm5 0h2V5h-2v12Zm5 0h2v-6h-2v6Z" fill="currentColor" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Criminal Records',
-    value: '856',
-    trend: '+8.2%',
-    trendPositive: true,
-    tone: 'red',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm6 1a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0 2c-1.8 0-3.3.8-4.2 2.1A5.6 5.6 0 0 0 5 21h2a3.6 3.6 0 0 1 3.5-3h2c1.7 0 3.1.7 4.1 2H19a4 4 0 0 0-4-6ZM9 13a6 6 0 0 0-6 6h2a4 4 0 0 1 4-4h1.2a6.2 6.2 0 0 1 2.6-2H9Z" fill="currentColor" />
-      </svg>
-    ),
-  },
-  {
-    title: 'Active Cases',
-    value: '342',
-    trend: '-4.1%',
-    trendPositive: false,
-    tone: 'yellow',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M6 3h9l5 5v13H6V3Zm2 2v14h10V9h-4V5H8Zm2 6h6v2h-6v-2Zm0 4h6v2h-6v-2Z" fill="currentColor" />
-      </svg>
-    ),
-  },
-  {
-    title: 'News Published',
-    value: '47',
-    trend: '+5.3%',
-    trendPositive: true,
-    tone: 'green',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M4 4h14v14H4V4Zm2 2v10h10V6H6Zm2 2h6v2H8V8Zm0 4h6v2H8v-2Zm11-4h1v8a2 2 0 0 1-2 2h-1v-2h1V8Z" fill="currentColor" />
-      </svg>
-    ),
-  },
-]
 
 const activityItems: ActivityItem[] = [
   {
@@ -130,26 +71,7 @@ const quickStats: QuickStat[] = [
 ]
 
 export default function AdminDashboard({ sectionName = 'Dashboard' }: AdminDashboardProps) {
-  const topSection = (
-    <section className="admin-dashboard__stats-grid" aria-label="Summary statistics">
-      {statCards.map(card => (
-        <article key={card.title} className="admin-dashboard__stat-card">
-          <div className="admin-dashboard__stat-top">
-            <span className={`admin-dashboard__stat-icon is-${card.tone}`}>{card.icon}</span>
-            <span
-              className={`admin-dashboard__stat-trend${
-                card.trendPositive ? ' is-positive' : ' is-negative'
-              }`}
-            >
-              {card.trend}
-            </span>
-          </div>
-          <p className="admin-dashboard__stat-title">{card.title}</p>
-          <p className="admin-dashboard__stat-value">{card.value}</p>
-        </article>
-      ))}
-    </section>
-  )
+  const topSection = <AdminStatCards />
 
   const primarySection = (
     <>


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added CSS styles and React component for admin dashboard stat cards, including four stat cards with different tones and icons. The stat cards display a title, value, and trend. The trend is shown as a percentage change with a positive or negative indicator.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-497](https://oshadadilshan.atlassian.net/browse/PEZY-497)

## Changes
- Added AdminStatCards.css with styles for stat cards grid, card layout, and trend indicators
- Created AdminStatCards.tsx component with stat card interface and sample data
- Implemented responsive design with media queries for different screen sizes

[PEZY-497]: https://oshadadilshan.atlassian.net/browse/PEZY-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ