### PR TITLE
PEZY-503: Implement Add Fine button and modal form

### DIFF
--- a/frontend/src/pages/AdminFineManagement.css
+++ b/frontend/src/pages/AdminFineManagement.css
@@ -38,6 +38,10 @@
   box-shadow: 0 8px 16px rgba(22, 40, 75, 0.22);
 }
 
+.admin-fines__add-btn:hover {
+  background: #172d55;
+}
+
 .admin-fines__add-btn svg {
   width: 20px;
   height: 20px;
@@ -228,6 +232,127 @@
 
 .admin-fines__summary-card strong.is-red {
   color: #d03434;
+}
+
+.admin-fines__modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: grid;
+  place-items: center;
+  z-index: 50;
+  padding: 18px;
+}
+
+.admin-fines__modal {
+  width: min(100%, 540px);
+  background: #ffffff;
+  border: 1px solid #d6dde7;
+  border-radius: 12px;
+  box-shadow: 0 24px 44px rgba(15, 23, 42, 0.24);
+  padding: 18px;
+}
+
+.admin-fines__modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.admin-fines__modal-header h3 {
+  margin: 0;
+  font-size: 1.45rem;
+  color: #2f3642;
+}
+
+.admin-fines__modal-close {
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: #eef2f7;
+  color: #334155;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.admin-fines__modal-close svg {
+  width: 18px;
+  height: 18px;
+}
+
+.admin-fines__modal-form {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-fines__modal-form label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.92rem;
+  color: #334155;
+  font-weight: 600;
+}
+
+.admin-fines__modal-form input,
+.admin-fines__modal-form select {
+  height: 42px;
+  border: 1px solid #ccd7e5;
+  border-radius: 9px;
+  background: #f8fafc;
+  color: #1f2937;
+  font-size: 0.95rem;
+  padding: 0 12px;
+  outline: none;
+}
+
+.admin-fines__modal-form input:focus,
+.admin-fines__modal-form select:focus {
+  border-color: #2290e8;
+  box-shadow: 0 0 0 3px rgba(34, 144, 232, 0.18);
+}
+
+.admin-fines__modal-form input[aria-invalid='true'] {
+  border-color: #d03434;
+  background: #fff5f5;
+}
+
+.admin-fines__field-error {
+  color: #d03434;
+  font-size: 0.82rem;
+  line-height: 1.25;
+  font-weight: 500;
+}
+
+.admin-fines__modal-actions {
+  margin-top: 6px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.admin-fines__btn-secondary,
+.admin-fines__btn-primary {
+  height: 40px;
+  border-radius: 9px;
+  padding: 0 14px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.admin-fines__btn-secondary {
+  border: 1px solid #cad5e3;
+  background: #f8fafc;
+  color: #374151;
+}
+
+.admin-fines__btn-primary {
+  border: 0;
+  background: #203968;
+  color: #ffffff;
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/pages/AdminFineManagement.tsx
+++ b/frontend/src/pages/AdminFineManagement.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react'
 import './AdminFineManagement.css'
 
 interface FineRecord {
@@ -9,7 +10,7 @@ interface FineRecord {
   status: 'paid' | 'pending' | 'overdue'
 }
 
-const fineRecords: FineRecord[] = [
+const initialFineRecords: FineRecord[] = [
   {
     id: 'F001',
     offender: 'Nimal Perera',
@@ -59,6 +60,111 @@ const statusLabel: Record<FineRecord['status'], string> = {
 }
 
 export default function AdminFineManagement() {
+  const [fineRecords, setFineRecords] = useState<FineRecord[]>(initialFineRecords)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [formValues, setFormValues] = useState<FineRecord>({
+    id: '',
+    offender: '',
+    violation: '',
+    amount: '',
+    date: '',
+    status: 'pending',
+  })
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof FineRecord, string>>>({})
+
+  const totalAmount = useMemo(
+    () =>
+      fineRecords.reduce((sum, record) => {
+        const numericValue = Number(record.amount.replace(/[^0-9.]/g, ''))
+        return sum + (Number.isFinite(numericValue) ? numericValue : 0)
+      }, 0),
+    [fineRecords],
+  )
+
+  const overdueCount = useMemo(
+    () => fineRecords.filter(record => record.status === 'overdue').length,
+    [fineRecords],
+  )
+
+  const openAddFineModal = () => {
+    setIsModalOpen(true)
+  }
+
+  const closeAddFineModal = () => {
+    setIsModalOpen(false)
+    setFormErrors({})
+    setFormValues({
+      id: '',
+      offender: '',
+      violation: '',
+      amount: '',
+      date: '',
+      status: 'pending',
+    })
+  }
+
+  const updateFormValue = <K extends keyof FineRecord>(field: K, value: FineRecord[K]) => {
+    setFormValues(previous => ({ ...previous, [field]: value }))
+
+    if (formErrors[field]) {
+      setFormErrors(previous => ({ ...previous, [field]: undefined }))
+    }
+  }
+
+  const validateForm = (): boolean => {
+    const nextErrors: Partial<Record<keyof FineRecord, string>> = {}
+
+    if (!formValues.id.trim()) {
+      nextErrors.id = 'Fine ID is required.'
+    } else if (fineRecords.some(record => record.id.toLowerCase() === formValues.id.trim().toLowerCase())) {
+      nextErrors.id = 'Fine ID already exists.'
+    }
+
+    if (!formValues.offender.trim()) {
+      nextErrors.offender = 'Offender name is required.'
+    }
+
+    if (!formValues.violation.trim()) {
+      nextErrors.violation = 'Violation is required.'
+    }
+
+    const rawAmount = formValues.amount.replace(/[^0-9.]/g, '')
+    const numericAmount = Number(rawAmount)
+
+    if (!rawAmount) {
+      nextErrors.amount = 'Amount is required.'
+    } else if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      nextErrors.amount = 'Amount must be a valid number greater than 0.'
+    }
+
+    if (!formValues.date) {
+      nextErrors.date = 'Date is required.'
+    }
+
+    setFormErrors(nextErrors)
+    return Object.keys(nextErrors).length === 0
+  }
+
+  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!validateForm()) {
+      return
+    }
+
+    const numericAmount = Number(formValues.amount.replace(/[^0-9.]/g, ''))
+    const formattedRecord: FineRecord = {
+      ...formValues,
+      id: formValues.id.trim().toUpperCase(),
+      offender: formValues.offender.trim(),
+      violation: formValues.violation.trim(),
+      amount: `LKR ${numericAmount.toLocaleString('en-LK')}`,
+    }
+
+    setFineRecords(previous => [formattedRecord, ...previous])
+    closeAddFineModal()
+  }
+
   return (
     <section className="admin-fines" aria-label="Fine management page">
       <header className="admin-fines__header">
@@ -67,7 +173,7 @@ export default function AdminFineManagement() {
           <p>Manage traffic fines and violations</p>
         </div>
 
-        <button type="button" className="admin-fines__add-btn">
+        <button type="button" className="admin-fines__add-btn" onClick={openAddFineModal}>
           <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M11 5h2v14h-2V5Zm-6 6h14v2H5v-2Z" fill="currentColor" />
           </svg>
@@ -143,17 +249,112 @@ export default function AdminFineManagement() {
       <section className="admin-fines__summary" aria-label="Fine summary statistics">
         <article className="admin-fines__summary-card">
           <p>Total Fines</p>
-          <strong>5</strong>
+          <strong>{fineRecords.length}</strong>
         </article>
         <article className="admin-fines__summary-card">
           <p>Total Amount Due</p>
-          <strong className="is-blue">LKR 1,350</strong>
+          <strong className="is-blue">LKR {totalAmount.toLocaleString('en-LK')}</strong>
         </article>
         <article className="admin-fines__summary-card">
           <p>Overdue Fines</p>
-          <strong className="is-red">1</strong>
+          <strong className="is-red">{overdueCount}</strong>
         </article>
       </section>
+
+      {isModalOpen ? (
+        <div className="admin-fines__modal-overlay" role="dialog" aria-modal="true" aria-labelledby="add-fine-title">
+          <div className="admin-fines__modal">
+            <div className="admin-fines__modal-header">
+              <h3 id="add-fine-title">Add Fine</h3>
+              <button type="button" className="admin-fines__modal-close" onClick={closeAddFineModal} aria-label="Close add fine form">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M6.4 5 12 10.6 17.6 5 19 6.4 13.4 12 19 17.6 17.6 19 12 13.4 6.4 19 5 17.6 10.6 12 5 6.4 6.4 5Z" fill="currentColor" />
+                </svg>
+              </button>
+            </div>
+
+            <form className="admin-fines__modal-form" onSubmit={handleFormSubmit}>
+              <label>
+                Fine ID
+                <input
+                  type="text"
+                  value={formValues.id}
+                  onChange={event => updateFormValue('id', event.target.value)}
+                  placeholder="F006"
+                  aria-invalid={Boolean(formErrors.id)}
+                />
+                {formErrors.id ? <span className="admin-fines__field-error">{formErrors.id}</span> : null}
+              </label>
+
+              <label>
+                Offender
+                <input
+                  type="text"
+                  value={formValues.offender}
+                  onChange={event => updateFormValue('offender', event.target.value)}
+                  placeholder="Offender name"
+                  aria-invalid={Boolean(formErrors.offender)}
+                />
+                {formErrors.offender ? <span className="admin-fines__field-error">{formErrors.offender}</span> : null}
+              </label>
+
+              <label>
+                Violation
+                <input
+                  type="text"
+                  value={formValues.violation}
+                  onChange={event => updateFormValue('violation', event.target.value)}
+                  placeholder="Violation type"
+                  aria-invalid={Boolean(formErrors.violation)}
+                />
+                {formErrors.violation ? <span className="admin-fines__field-error">{formErrors.violation}</span> : null}
+              </label>
+
+              <label>
+                Amount (LKR)
+                <input
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={formValues.amount.replace(/[^0-9.]/g, '')}
+                  onChange={event => updateFormValue('amount', event.target.value)}
+                  placeholder="250"
+                  aria-invalid={Boolean(formErrors.amount)}
+                />
+                {formErrors.amount ? <span className="admin-fines__field-error">{formErrors.amount}</span> : null}
+              </label>
+
+              <label>
+                Date
+                <input
+                  type="date"
+                  value={formValues.date}
+                  onChange={event => updateFormValue('date', event.target.value)}
+                  aria-invalid={Boolean(formErrors.date)}
+                />
+                {formErrors.date ? <span className="admin-fines__field-error">{formErrors.date}</span> : null}
+              </label>
+
+              <label>
+                Status
+                <select
+                  value={formValues.status}
+                  onChange={event => updateFormValue('status', event.target.value as FineRecord['status'])}
+                >
+                  <option value="paid">Paid</option>
+                  <option value="pending">Pending</option>
+                  <option value="overdue">Overdue</option>
+                </select>
+              </label>
+
+              <div className="admin-fines__modal-actions">
+                <button type="button" className="admin-fines__btn-secondary" onClick={closeAddFineModal}>Cancel</button>
+                <button type="submit" className="admin-fines__btn-primary">Save Fine</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
     </section>
   )
 }


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The '+ Add Fine' button has been implemented to open a modal form, allowing users to input fine details such as offender search, violation type, fine amount, and date. This feature enhances the fine management system by providing a user-friendly interface for adding new fines. The modal form is styled with a responsive design and includes input validation.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-503](https://oshadadilshan.atlassian.net/browse/PEZY-503)

## Changes
- Added CSS styles for the '+ Add Fine' button and modal form
- Implemented modal overlay, header, and form layout
- Added input fields for offender search, violation type, fine amount, and date
- Styled input fields with validation and focus states

[PEZY-503]: https://oshadadilshan.atlassian.net/browse/PEZY-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ