### PR TITLE
PEZY-507: Admin Fine Management Summary Statistics

### DIFF
--- a/frontend/src/pages/AdminFineManagement.css
+++ b/frontend/src/pages/AdminFineManagement.css
@@ -252,6 +252,13 @@
   gap: 14px;
 }
 
+.admin-fines__summary-note {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
 .admin-fines__summary-card {
   background: #ffffff;
   border: 1px solid #d6dde7;

--- a/frontend/src/pages/AdminFineManagement.tsx
+++ b/frontend/src/pages/AdminFineManagement.tsx
@@ -81,20 +81,6 @@ export default function AdminFineManagement() {
   })
   const [formErrors, setFormErrors] = useState<Partial<Record<keyof FineRecord, string>>>({})
 
-  const totalAmount = useMemo(
-    () =>
-      fineRecords.reduce((sum, record) => {
-        const numericValue = Number(record.amount.replace(/[^0-9.]/g, ''))
-        return sum + (Number.isFinite(numericValue) ? numericValue : 0)
-      }, 0),
-    [fineRecords],
-  )
-
-  const overdueCount = useMemo(
-    () => fineRecords.filter(record => record.status === 'overdue').length,
-    [fineRecords],
-  )
-
   const filteredFineRecords = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase()
 
@@ -113,6 +99,20 @@ export default function AdminFineManagement() {
       return matchesStatus && matchesSearch
     })
   }, [fineRecords, searchQuery, statusFilter])
+
+  const filteredTotalAmount = useMemo(
+    () =>
+      filteredFineRecords.reduce((sum, record) => {
+        const numericValue = Number(record.amount.replace(/[^0-9.]/g, ''))
+        return sum + (Number.isFinite(numericValue) ? numericValue : 0)
+      }, 0),
+    [filteredFineRecords],
+  )
+
+  const filteredOverdueCount = useMemo(
+    () => filteredFineRecords.filter(record => record.status === 'overdue').length,
+    [filteredFineRecords],
+  )
 
   const openAddFineModal = () => {
     setModalMode('add')
@@ -381,17 +381,18 @@ export default function AdminFineManagement() {
       </div>
 
       <section className="admin-fines__summary" aria-label="Fine summary statistics">
+        <p className="admin-fines__summary-note">Summary based on current table results</p>
         <article className="admin-fines__summary-card">
           <p>Total Fines</p>
-          <strong>{fineRecords.length}</strong>
+          <strong>{filteredFineRecords.length}</strong>
         </article>
         <article className="admin-fines__summary-card">
           <p>Total Amount Due</p>
-          <strong className="is-blue">LKR {totalAmount.toLocaleString('en-LK')}</strong>
+          <strong className="is-blue">LKR {filteredTotalAmount.toLocaleString('en-LK')}</strong>
         </article>
         <article className="admin-fines__summary-card">
           <p>Overdue Fines</p>
-          <strong className="is-red">{overdueCount}</strong>
+          <strong className="is-red">{filteredOverdueCount}</strong>
         </article>
       </section>
 


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added three summary statistic cards below the fine table, displaying Total Fines count, Total Amount Due in LKR, and Overdue Fines count. The statistics are based on the current table results and are updated dynamically. The Total Amount Due is displayed in blue and the Overdue Fines count is displayed in red.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-507](https://oshadadilshan.atlassian.net/browse/PEZY-507)

## Changes
- Added CSS styles for the summary statistic cards
- Updated the `AdminFineManagement.tsx` file to calculate the total amount and overdue count based on the filtered fine records
- Added a note to indicate that the summary statistics are based on the current table results

[PEZY-507]: https://oshadadilshan.atlassian.net/browse/PEZY-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ