### PR TITLE
PEZY-510: Implement Add Criminal Record form

### DIFF
--- a/frontend/src/pages/AdminCriminalRecords.tsx
+++ b/frontend/src/pages/AdminCriminalRecords.tsx
@@ -466,7 +466,7 @@ export default function AdminCriminalRecords() {
                   type="text"
                   value={formValues.id}
                   onChange={event => updateFormValue('id', event.target.value)}
-                  placeholder="CR006"
+                  placeholder="e.g., CR006"
                   disabled={modalMode === 'view'}
                   aria-invalid={Boolean(formErrors.id)}
                 />
@@ -492,7 +492,7 @@ export default function AdminCriminalRecords() {
                   type="text"
                   value={formValues.caseNumber}
                   onChange={event => updateFormValue('caseNumber', event.target.value)}
-                  placeholder="CASE-2026-0001"
+                  placeholder="e.g., CASE-2026-0001"
                   disabled={modalMode === 'view'}
                   aria-invalid={Boolean(formErrors.caseNumber)}
                 />


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The code changes involve updating the placeholder text for the 'id' and 'caseNumber' input fields in the AdminCriminalRecords form to include examples. This improvement aims to provide clearer guidance for users when entering data.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other
## Jira Reference
- Issue: [PEZY-510](https://oshadadilshan.atlassian.net/browse/PEZY-510)
## Changes
- Updated the 'id' input field placeholder from 'CR006' to 'e.g., CR006'
- Updated the 'caseNumber' input field placeholder from 'CASE-2026-0001' to 'e.g., CASE-2026-0001'

[PEZY-510]: https://oshadadilshan.atlassian.net/browse/PEZY-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ