### PR TITLE
PEZY-511: Implement view criminal detail modal

### DIFF
--- a/frontend/src/pages/AdminCriminalRecords.css
+++ b/frontend/src/pages/AdminCriminalRecords.css
@@ -442,7 +442,7 @@
 .admin-criminals__detail-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
+  gap: 9px;
 }
 
 .admin-criminals__detail-item {


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The code change updates the CSS for the admin criminal records page, specifically adjusting the grid gap in the detail grid from 10px to 9px. This modification aims to refine the layout and improve the overall user experience. The change is related to the implementation of a read-only modal for viewing criminal details.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-511](https://oshadadilshan.atlassian.net/browse/PEZY-511)

## Changes
- Updated the `gap` property in the `.admin-criminals__detail-grid` class from `10px` to `9px`

[PEZY-511]: https://oshadadilshan.atlassian.net/browse/PEZY-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ