### PR TITLE
PEZY-514: Admin News Management

### DIFF
--- a/frontend/src/config/routes.tsx
+++ b/frontend/src/config/routes.tsx
@@ -12,6 +12,7 @@ import AdminLayout from '../layouts/AdminLayout'
 import AdminDashboard from '../pages/AdminDashboard'
 import AdminFineManagement from '../pages/AdminFineManagement'
 import AdminCriminalRecords from '../pages/AdminCriminalRecords'
+import AdminNewsManagement from '../pages/AdminNewsManagement'
 import NotFound from '../pages/NotFound'
 
 export interface RouteConfig {
@@ -97,7 +98,7 @@ export const routes: RouteConfig[] = [
     path: '/admin/news',
     element: (
       <AdminLayout>
-        <AdminDashboard sectionName="News Management" />
+        <AdminNewsManagement />
       </AdminLayout>
     ),
     name: 'Admin News',

--- a/frontend/src/pages/AdminNewsManagement.css
+++ b/frontend/src/pages/AdminNewsManagement.css
@@ -1,0 +1,363 @@
+.admin-news {
+  text-align: left;
+}
+
+.admin-news__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.admin-news__header h2 {
+  margin: 0;
+  font-size: 2.05rem;
+  line-height: 1.15;
+  color: #2f3642;
+}
+
+.admin-news__header p {
+  margin-top: 8px;
+  color: #6b7280;
+  font-size: 0.96rem;
+}
+
+.admin-news__add-btn {
+  height: 46px;
+  border: 0;
+  border-radius: 10px;
+  background: #203968;
+  color: #ffffff;
+  font-size: 1.05rem;
+  font-weight: 600;
+  padding: 0 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(22, 40, 75, 0.22);
+}
+
+.admin-news__add-btn:hover {
+  background: #172d55;
+}
+
+.admin-news__add-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+.admin-news__toolbar {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+}
+
+.admin-news__search-wrap {
+  height: 48px;
+  border: 1px solid #cfd8e3;
+  border-radius: 10px;
+  background: #f6f8fb;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+}
+
+.admin-news__search-wrap svg {
+  width: 20px;
+  height: 20px;
+  color: #111827;
+}
+
+.admin-news__search-wrap input {
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #374151;
+  font-size: 0.98rem;
+}
+
+.admin-news__search-wrap input::placeholder {
+  color: #9ca3af;
+}
+
+.admin-news__filter-wrap {
+  position: relative;
+}
+
+.admin-news__filter-btn {
+  height: 48px;
+  border: 1px solid #cfd8e3;
+  border-radius: 10px;
+  background: #f6f8fb;
+  color: #374151;
+  font-size: 1rem;
+  padding: 0 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.admin-news__filter-btn svg {
+  width: 20px;
+  height: 20px;
+}
+
+.admin-news__filter-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: 188px;
+  background: #ffffff;
+  border: 1px solid #d6dde7;
+  border-radius: 10px;
+  padding: 6px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.14);
+  z-index: 5;
+}
+
+.admin-news__filter-item {
+  width: 100%;
+  height: 36px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #374151;
+  text-align: left;
+  padding: 0 10px;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.admin-news__filter-item:hover {
+  background: #f2f6fb;
+}
+
+.admin-news__filter-item.is-active {
+  background: #e6f2ff;
+  color: #1f6fd6;
+  font-weight: 600;
+}
+
+.admin-news__list {
+  margin-top: 16px;
+  display: grid;
+  gap: 14px;
+}
+
+.admin-news__card {
+  background: #ffffff;
+  border: 1px solid #d6dde7;
+  border-radius: 10px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  padding: 16px;
+}
+
+.admin-news__card--empty {
+  grid-template-columns: 1fr;
+}
+
+.admin-news__card--empty p {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 0.95rem;
+  text-align: center;
+  padding: 10px 0;
+}
+
+.admin-news__card-main {
+  min-width: 0;
+}
+
+.admin-news__card-tags {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.admin-news__id {
+  color: #2092eb;
+  font-size: 0.84rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.admin-news__status {
+  height: 22px;
+  border-radius: 999px;
+  padding: 0 10px;
+  font-size: 0.77rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+}
+
+.admin-news__status.is-published {
+  background: #d8f2e2;
+  color: #1d9150;
+}
+
+.admin-news__status.is-draft {
+  background: #eceff3;
+  color: #6b7280;
+}
+
+.admin-news__status.is-scheduled {
+  background: #dce8ff;
+  color: #2f6de1;
+}
+
+.admin-news__card h3 {
+  margin: 10px 0 8px;
+  color: #2f3642;
+  font-size: 1.9rem;
+  line-height: 1.22;
+}
+
+.admin-news__excerpt {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.admin-news__meta {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid #e4e9f0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #7a8190;
+  font-size: 0.86rem;
+}
+
+.admin-news__views {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.admin-news__views svg {
+  width: 14px;
+  height: 14px;
+}
+
+.admin-news__actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding-left: 8px;
+}
+
+.admin-news__action-btn {
+  width: 30px;
+  height: 30px;
+  border: 0;
+  background: transparent;
+  color: #111827;
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.admin-news__action-btn:hover {
+  background: #eff3f8;
+}
+
+.admin-news__action-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.admin-news__summary-grid {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.admin-news__summary-card {
+  background: #ffffff;
+  border: 1px solid #d6dde7;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
+.admin-news__summary-card p {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.86rem;
+}
+
+.admin-news__summary-card strong {
+  display: inline-block;
+  margin-top: 7px;
+  color: #2f3642;
+  font-size: 2rem;
+  line-height: 1.1;
+}
+
+.admin-news__summary-card strong.is-green {
+  color: #1d9150;
+}
+
+.admin-news__summary-card strong.is-blue {
+  color: #2290e8;
+}
+
+@media (max-width: 980px) {
+  .admin-news__header {
+    flex-direction: column;
+  }
+
+  .admin-news__add-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .admin-news__toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-news__filter-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .admin-news__card {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-news__actions {
+    align-items: center;
+    justify-content: flex-end;
+    padding-left: 0;
+  }
+
+  .admin-news__summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-news__header h2 {
+    font-size: 1.6rem;
+  }
+
+  .admin-news__card h3 {
+    font-size: 1.25rem;
+  }
+
+  .admin-news__summary-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/AdminNewsManagement.tsx
+++ b/frontend/src/pages/AdminNewsManagement.tsx
@@ -1,0 +1,273 @@
+import { useMemo, useState } from 'react'
+import './AdminNewsManagement.css'
+
+type ArticleStatus = 'published' | 'draft' | 'scheduled'
+
+interface NewsArticle {
+  id: string
+  title: string
+  summary: string
+  author: string
+  date: string
+  status: ArticleStatus
+  views?: number
+}
+
+const initialArticles: NewsArticle[] = [
+  {
+    id: 'N001',
+    title: 'New Traffic Safety Initiative Launched',
+    summary: 'The police department announces a new initiative to improve traffic safety on major roads.',
+    author: 'Officer Smith',
+    date: '1/20/2024',
+    status: 'published',
+    views: 1247,
+  },
+  {
+    id: 'N002',
+    title: 'Community Policing Program Expansion',
+    summary: 'Expanding community policing initiatives to create safer neighborhoods.',
+    author: 'Chief Johnson',
+    date: '1/18/2024',
+    status: 'published',
+    views: 892,
+  },
+  {
+    id: 'N003',
+    title: 'Crime Prevention Tips for Residents',
+    summary: 'Essential tips to keep your home and family safe from crime.',
+    author: 'Detective Brown',
+    date: '1/15/2024',
+    status: 'published',
+    views: 2156,
+  },
+  {
+    id: 'N004',
+    title: 'Annual Police Department Report',
+    summary: 'Review of department activities and achievements in 2023.',
+    author: 'Captain Davis',
+    date: '1/25/2024',
+    status: 'draft',
+  },
+  {
+    id: 'N005',
+    title: 'Emergency Response Updates',
+    summary: 'Latest updates on emergency response protocols and procedures.',
+    author: 'Dispatcher Lee',
+    date: '2/1/2024',
+    status: 'scheduled',
+  },
+]
+
+const statusLabel: Record<ArticleStatus, string> = {
+  published: 'Published',
+  draft: 'Draft',
+  scheduled: 'Scheduled',
+}
+
+type StatusFilter = 'all' | ArticleStatus
+
+export default function AdminNewsManagement() {
+  const [articles] = useState<NewsArticle[]>(initialArticles)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false)
+
+  const filteredArticles = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase()
+
+    return articles.filter(article => {
+      const matchesStatus = statusFilter === 'all' ? true : article.status === statusFilter
+
+      if (!normalizedQuery) {
+        return matchesStatus
+      }
+
+      const matchesSearch =
+        article.id.toLowerCase().includes(normalizedQuery) ||
+        article.title.toLowerCase().includes(normalizedQuery) ||
+        article.author.toLowerCase().includes(normalizedQuery)
+
+      return matchesStatus && matchesSearch
+    })
+  }, [articles, searchQuery, statusFilter])
+
+  const totalArticles = filteredArticles.length
+  const totalPublished = filteredArticles.filter(article => article.status === 'published').length
+  const totalDrafts = filteredArticles.filter(article => article.status === 'draft').length
+  const totalViews = filteredArticles.reduce((sum, article) => sum + (article.views ?? 0), 0)
+
+  const closeFilterMenu = () => {
+    setIsFilterMenuOpen(false)
+  }
+
+  const handleStatusFilterChange = (filter: StatusFilter) => {
+    setStatusFilter(filter)
+    closeFilterMenu()
+  }
+
+  return (
+    <section className="admin-news" aria-label="News management page">
+      <header className="admin-news__header">
+        <div>
+          <h2>News Management</h2>
+          <p>Publish and manage news articles for the public</p>
+        </div>
+
+        <button type="button" className="admin-news__add-btn">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M11 5h2v14h-2V5Zm-6 6h14v2H5v-2Z" fill="currentColor" />
+          </svg>
+          <span>New Article</span>
+        </button>
+      </header>
+
+      <div className="admin-news__toolbar">
+        <label htmlFor="news-search" className="admin-news__search-wrap">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M10.5 3a7.5 7.5 0 1 1 0 15 7.5 7.5 0 0 1 0-15Zm0 2a5.5 5.5 0 1 0 3.45 9.78l4.13 4.13 1.42-1.42-4.13-4.13A5.5 5.5 0 0 0 10.5 5Z" fill="currentColor" />
+          </svg>
+          <input
+            id="news-search"
+            type="text"
+            placeholder="Search by title, author, or slug..."
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+          />
+        </label>
+
+        <div className="admin-news__filter-wrap">
+          <button
+            type="button"
+            className="admin-news__filter-btn"
+            onClick={() => setIsFilterMenuOpen(previous => !previous)}
+            aria-expanded={isFilterMenuOpen}
+            aria-haspopup="menu"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M3 5h18v2l-7 7v5l-4 2v-7L3 7V5Zm3 2 6 6.2V19l1-.5v-5.3L19 7H6Z" fill="currentColor" />
+            </svg>
+            <span>{statusFilter === 'all' ? 'Filter' : statusLabel[statusFilter]}</span>
+          </button>
+
+          {isFilterMenuOpen ? (
+            <div className="admin-news__filter-menu" role="menu" aria-label="Filter news by status">
+              <button
+                type="button"
+                className={`admin-news__filter-item${statusFilter === 'all' ? ' is-active' : ''}`}
+                onClick={() => handleStatusFilterChange('all')}
+                role="menuitem"
+              >
+                All statuses
+              </button>
+              <button
+                type="button"
+                className={`admin-news__filter-item${statusFilter === 'published' ? ' is-active' : ''}`}
+                onClick={() => handleStatusFilterChange('published')}
+                role="menuitem"
+              >
+                Published
+              </button>
+              <button
+                type="button"
+                className={`admin-news__filter-item${statusFilter === 'draft' ? ' is-active' : ''}`}
+                onClick={() => handleStatusFilterChange('draft')}
+                role="menuitem"
+              >
+                Draft
+              </button>
+              <button
+                type="button"
+                className={`admin-news__filter-item${statusFilter === 'scheduled' ? ' is-active' : ''}`}
+                onClick={() => handleStatusFilterChange('scheduled')}
+                role="menuitem"
+              >
+                Scheduled
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <section className="admin-news__list" aria-label="News articles list">
+        {filteredArticles.length ? (
+          filteredArticles.map(article => (
+            <article key={article.id} className="admin-news__card">
+              <div className="admin-news__card-main">
+                <div className="admin-news__card-tags">
+                  <span className="admin-news__id">{article.id}</span>
+                  <span className={`admin-news__status is-${article.status}`}>{statusLabel[article.status]}</span>
+                </div>
+
+                <h3>{article.title}</h3>
+                <p className="admin-news__excerpt">{article.summary}</p>
+
+                <footer className="admin-news__meta">
+                  <span>{article.author}</span>
+                  <span aria-hidden="true">•</span>
+                  <span>{article.date}</span>
+                  {typeof article.views === 'number' ? (
+                    <>
+                      <span aria-hidden="true">•</span>
+                      <span className="admin-news__views">
+                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                          <path d="M12 5c4.8 0 8.7 2.8 10 7-1.3 4.2-5.2 7-10 7S3.3 16.2 2 12c1.3-4.2 5.2-7 10-7Zm0 2c-3.7 0-6.8 2-8 5 1.2 3 4.3 5 8 5s6.8-2 8-5c-1.2-3-4.3-5-8-5Zm0 2.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5Z" fill="currentColor" />
+                        </svg>
+                        <span>{article.views.toLocaleString('en-US')} views</span>
+                      </span>
+                    </>
+                  ) : null}
+                </footer>
+              </div>
+
+              <div className="admin-news__actions" aria-label={`Actions for ${article.title}`}>
+                {article.status === 'published' ? (
+                  <button type="button" className="admin-news__action-btn" aria-label={`Preview ${article.title}`}>
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path d="M12 5c4.8 0 8.7 2.8 10 7-1.3 4.2-5.2 7-10 7S3.3 16.2 2 12c1.3-4.2 5.2-7 10-7Zm0 2c-3.7 0-6.8 2-8 5 1.2 3 4.3 5 8 5s6.8-2 8-5c-1.2-3-4.3-5-8-5Zm0 2.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5Z" fill="currentColor" />
+                    </svg>
+                  </button>
+                ) : null}
+
+                <button type="button" className="admin-news__action-btn" aria-label={`Edit ${article.title}`}>
+                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M3 17.2V21h3.8L17.9 9.9 14.1 6 3 17.2Zm2 2.8v-2l9.1-9.1 2 2-9.1 9.1H5Zm14.7-11.3a1 1 0 0 0 0-1.4l-3-3a1 1 0 0 0-1.4 0l-1.2 1.2 4.4 4.4 1.2-1.2Z" fill="currentColor" />
+                  </svg>
+                </button>
+
+                <button type="button" className="admin-news__action-btn" aria-label={`Delete ${article.title}`}>
+                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M7 4h10l1 2h4v2H2V6h4l1-2Zm1 6h2v8H8v-8Zm6 0h2v8h-2v-8ZM6 8h12l-1 12H7L6 8Z" fill="currentColor" />
+                  </svg>
+                </button>
+              </div>
+            </article>
+          ))
+        ) : (
+          <article className="admin-news__card admin-news__card--empty">
+            <p>No articles found for the current search and filter.</p>
+          </article>
+        )}
+      </section>
+
+      <section className="admin-news__summary-grid" aria-label="News summary statistics">
+        <article className="admin-news__summary-card">
+          <p>Total Articles</p>
+          <strong>{totalArticles}</strong>
+        </article>
+        <article className="admin-news__summary-card">
+          <p>Published</p>
+          <strong className="is-green">{totalPublished}</strong>
+        </article>
+        <article className="admin-news__summary-card">
+          <p>Drafts</p>
+          <strong>{totalDrafts}</strong>
+        </article>
+        <article className="admin-news__summary-card">
+          <p>Total Views</p>
+          <strong className="is-blue">{totalViews.toLocaleString('en-US')}</strong>
+        </article>
+      </section>
+    </section>
+  )
+}


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added a new page for admin news management, including a list of news articles with their ID, status, title, preview, author, date, view count, and action icons. The news article list is displayed in a card format. A new route was added to the admin layout for news management.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-514](https://oshadadilshan.atlassian.net/browse/PEZY-514)

## Changes
- Added a new route for admin news management
- Created a new page for admin news management with a list of news articles
- Added CSS styles for the news article list and toolbar

[PEZY-514]: https://oshadadilshan.atlassian.net/browse/PEZY-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ