### PR TITLE
PEZY-518: Admin News Summary Stats

### DIFF
--- a/frontend/src/pages/AdminNewsManagement.css
+++ b/frontend/src/pages/AdminNewsManagement.css
@@ -279,7 +279,9 @@
 }
 
 .admin-news__summary-grid {
-  margin-top: 16px;
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #e4e9f0;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The code changes involve updating the AdminNewsManagement.css file to add a summary grid with statistics below the news list. The changes include increasing the margin-top and adding padding-top and a border-top to the .admin-news__summary-grid class. This will provide a clear visual separation between the news list and the summary statistics.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-518](https://oshadadilshan.atlassian.net/browse/PEZY-518)

## Changes
- Increased margin-top of .admin-news__summary-grid from 16px to 24px
- Added padding-top of 20px to .admin-news__summary-grid
- Added border-top of 1px solid #e4e9f0 to .admin-news__summary-grid

[PEZY-518]: https://oshadadilshan.atlassian.net/browse/PEZY-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ