### PR TITLE
PEZY-463: Implement Hamburger Menu for Mobile Responsive Navigation

### DIFF
--- a/frontend/src/components/NavBar.css
+++ b/frontend/src/components/NavBar.css
@@ -146,6 +146,7 @@
   color: #fff;
   cursor: pointer;
   box-shadow: 0 6px 16px rgba(3, 105, 161, 0.28);
+  transition: background-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
 }
 
 .home-police__menu-toggle-icon {
@@ -161,6 +162,7 @@
   height: 2px;
   border-radius: 999px;
   background: currentColor;
+  transition: transform 180ms ease, opacity 180ms ease, width 180ms ease;
 }
 
 .home-police__menu-toggle-text {
@@ -176,6 +178,23 @@
 
 .home-police__menu-toggle:active {
   transform: translateY(1px);
+}
+
+.home-police__menu-toggle.is-open {
+  background: rgba(255, 255, 255, 0.34);
+  box-shadow: 0 10px 24px rgba(3, 105, 161, 0.38);
+}
+
+.home-police__menu-toggle.is-open .home-police__menu-toggle-icon span:nth-child(1) {
+  transform: translateY(5px) rotate(45deg);
+}
+
+.home-police__menu-toggle.is-open .home-police__menu-toggle-icon span:nth-child(2) {
+  opacity: 0;
+}
+
+.home-police__menu-toggle.is-open .home-police__menu-toggle-icon span:nth-child(3) {
+  transform: translateY(-5px) rotate(-45deg);
 }
 
 .home-police__mobile-menu {
@@ -200,25 +219,56 @@
   }
 
   .home-police__menu {
-    display: none;
     grid-column: 1 / -1;
     grid-row: 2;
     width: 100%;
     flex-direction: column;
     align-items: stretch;
     gap: 0;
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    margin-top: 0;
+    pointer-events: none;
+    transform: translateY(-0.35rem);
+    transition: max-height 240ms ease, opacity 180ms ease, transform 180ms ease, margin-top 180ms ease;
   }
 
   .home-police__menu.is-open {
     display: flex;
+    max-height: 24rem;
+    opacity: 1;
+    margin-top: 0.35rem;
+    pointer-events: auto;
+    transform: translateY(0);
+    padding: 0.35rem;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: linear-gradient(135deg, rgba(2, 132, 199, 0.98) 0%, rgba(3, 105, 161, 0.98) 100%);
+    box-shadow: 0 18px 34px rgba(1, 34, 58, 0.28);
+    backdrop-filter: blur(10px);
   }
 
   .home-police__menu-item {
     width: 100%;
     justify-content: flex-start;
-    padding: 0.75rem 0.9rem;
+    padding: 0.85rem 0.95rem;
     text-align: left;
-    border-radius: 0;
+    border-radius: 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .home-police__menu-item:last-child {
+    border-bottom: 0;
+  }
+
+  .home-police__menu-item:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .home-police__menu-item.is-active {
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: none;
   }
 
   .home-police__search {

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -61,10 +61,11 @@ export default function NavBar() {
       <div className="home-police__container home-police__menu-row">
         <button
           type="button"
-          className="home-police__menu-toggle"
+          className={`home-police__menu-toggle${menuOpen ? ' is-open' : ''}`}
           onClick={toggleMenu}
-          aria-label="Toggle menu"
+          aria-label={menuOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
         >
           <span className="home-police__menu-toggle-icon" aria-hidden="true">
             <span />
@@ -74,7 +75,7 @@ export default function NavBar() {
           <span className="home-police__menu-toggle-text">MENU</span>
         </button>
 
-        <nav className={`home-police__menu${menuOpen ? ' is-open' : ''}`} aria-label="Primary">
+        <nav id="primary-navigation" className={`home-police__menu${menuOpen ? ' is-open' : ''}`} aria-label="Primary">
           {primaryMenu.map(item => (
             <button
               key={item.label}


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Implemented a hamburger menu for mobile responsive navigation, replacing links with a hamburger icon on mobile devices (<768px) and adding a slide-down menu on click. The menu closes when clicked outside. This change enhances the user experience on mobile devices.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-463](https://oshadadilshan.atlassian.net/browse/PEZY-463)

## Changes
- Added CSS transitions for a smoother menu toggle experience
- Introduced a new class `.home-police__menu-toggle.is-open` to style the open state of the hamburger menu
- Modified the `.home-police__menu` class to hide the menu by default and show it when the `.is-open` class is applied
- Updated the `.home-police__menu-item` class to improve styling and add hover effects

[PEZY-463]: https://oshadadilshan.atlassian.net/browse/PEZY-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ