### PR TITLE
PEZY-401: Create authorize(...roles) middleware

### DIFF
--- a/backend/src/middlewares/authorize.js
+++ b/backend/src/middlewares/authorize.js
@@ -1,0 +1,29 @@
+export const authorize = (...roles) => {
+  return (req, res, next) => {
+    try {
+      // Check if user is authenticated (authenticate middleware should run first)
+      if (!req.user) {
+        return res.status(401).json({
+          success: false,
+          message: 'User not authenticated. Please provide a valid token.',
+        });
+      }
+
+      // Check if user's role is in allowed roles
+      if (!roles.includes(req.user.role)) {
+        return res.status(403).json({
+          success: false,
+          message: `Access denied. Required role(s): ${roles.join(', ')}. Your role: ${req.user.role}`,
+        });
+      }
+
+      next();
+    } catch (error) {
+      return res.status(500).json({
+        success: false,
+        message: 'Authorization check failed',
+        error: error.message,
+      });
+    }
+  };
+};


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The authorize middleware checks if the user's role is in the allowed roles. It returns a 403 status code if the user's role is not in the allowed roles. This middleware is designed to be used as route-level middleware.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-401](https://oshadadilshan.atlassian.net/browse/PEZY-401)

## Changes
- Created a new middleware function called authorize that takes in a variable number of roles
- Implemented a check to ensure the user is authenticated before checking their role
- Added error handling to return a 500 status code if the authorization check fails

[PEZY-401]: https://oshadadilshan.atlassian.net/browse/PEZY-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ