### PR TITLE
PEZY-542: Add current user profile endpoint

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -345,3 +345,58 @@ export const logout = async (req, res) => {
     });
   }
 };
+
+/**
+ * Get Current User - Fetch authenticated user's profile
+ * GET /api/auth/me
+ * Headers: { Authorization: Bearer <token> }
+ * Returns: { success, user }
+ */
+export const getCurrentUser = async (req, res, next) => {
+  try {
+    // User info is already attached to request by authenticate middleware
+    const user = req.user;
+
+    if (!user || !user.id) {
+      return res.status(401).json({
+        success: false,
+        message: 'User not authenticated',
+      });
+    }
+
+    // Fetch fresh user data from database to get latest status (is_online, last_login_at)
+    const supabase = getSupabaseClient();
+    const { data: freshUserData, error } = await supabase
+      .from('users')
+      .select('*')
+      .eq('id', user.id)
+      .single();
+
+    if (error || !freshUserData) {
+      return res.status(404).json({
+        success: false,
+        message: 'User not found',
+      });
+    }
+
+    // Return user profile with fresh data
+    return res.status(200).json({
+      success: true,
+      user: {
+        id: freshUserData.id,
+        email: freshUserData.email,
+        name: freshUserData.name,
+        role: freshUserData.role,
+        phone: freshUserData.phone,
+        department: freshUserData.department,
+        badge_number: freshUserData.badge_number,
+        is_active: freshUserData.is_active,
+        is_online: freshUserData.is_online,
+        last_login_at: freshUserData.last_login_at,
+        last_logout_at: freshUserData.last_logout_at,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,5 +1,6 @@
 import express from 'express';
-import { requestOTP, verifyOTP, refreshAccessToken, logout } from '../controllers/authController.js';
+import { requestOTP, verifyOTP, refreshAccessToken, logout, getCurrentUser } from '../controllers/authController.js';
+import { authenticate } from '../middlewares/authenticate.js';
 
 const router = express.Router();
 
@@ -18,6 +19,14 @@ router.post('/request-otp', requestOTP);
  * Returns: { accessToken, refreshToken, user }
  */
 router.post('/verify-otp', verifyOTP);
+
+/**
+ * GET /api/auth/me
+ * Get current authenticated user's profile
+ * Headers: { Authorization: Bearer <token> }
+ * Returns: { success, user }
+ */
+router.get('/me', authenticate, getCurrentUser);
 
 /**
  * POST /api/auth/refresh-token


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added a new endpoint to fetch the authenticated user's own profile. The endpoint uses the authenticate middleware to extract the user ID from the JWT token and returns the user's details. The user's data is fetched from the database to get the latest status.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-542](https://oshadadilshan.atlassian.net/browse/PEZY-542)

## Changes
- Added a new function `getCurrentUser` in `authController.js` to handle the GET /api/auth/me endpoint
- Updated `authRoutes.js` to include the new endpoint
- Used authenticate middleware to extract user ID from JWT token

[PEZY-542]: https://oshadadilshan.atlassian.net/browse/PEZY-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ