### PR TITLE
PEZY-344: Save JWT access token to flutter_secure_storage

### DIFF
--- a/mobile/pezy_mobile/lib/features/auth/TOKEN_MANAGEMENT.md
+++ b/mobile/pezy_mobile/lib/features/auth/TOKEN_MANAGEMENT.md
@@ -1,0 +1,190 @@
+/// JWT Token Management Guide
+///
+/// This file documents how JWT tokens are saved, stored, and used in the PEZY mobile app.
+///
+/// ============================================================================
+/// 1. TOKEN SAVING FLOW
+/// ============================================================================
+///
+/// Step 1: OTP Verification
+/// When user enters OTP in OtpVerificationScreen:
+/// - Calls otpNotifier.verifyOtp()
+/// - OTP notifier calls authRepository.verifyOtp(temporaryId, otp)
+/// - Backend returns: { accessToken, refreshToken, user }
+///
+/// Step 2: Secure Storage
+/// In auth_repository.dart, verifyOtp() method:
+/// ```dart
+/// await _tokenStorage.saveTokens(
+///   accessToken: response.accessToken!,
+///   refreshToken: response.refreshToken!,
+///   userEmail: response.user!.email,
+///   userId: response.user!.id,
+///   userName: response.user!.name,
+/// );
+/// ```
+/// - Uses flutter_secure_storage (encrypted on device)
+/// - Saves: accessToken, refreshToken, userEmail, userId, userName
+/// - Data persists across app restarts
+///
+/// Step 3: Auth State Update
+/// In otp_verification_screen.dart, _handleVerifyOtp():
+/// ```dart
+/// final authNotifier = ref.read(authProvider.notifier);
+/// authNotifier.setAuthenticatedUser(
+///   id: userId,
+///   email: userEmail,
+///   name: userName,
+///   role: 'police_officer',
+///   accessToken: accessToken,
+/// );
+/// ```
+/// - Updates global auth state
+/// - Makes user data available throughout app
+/// - Signals app that user is authenticated
+///
+/// ============================================================================
+/// 2. TOKEN STORAGE LOCATION
+/// ============================================================================
+///
+/// File: lib/features/auth/data/services/token_storage_service.dart
+///
+/// Keys stored in flutter_secure_storage:
+/// - 'access_token'   → JWT access token (short-lived, 15 min default)
+/// - 'refresh_token'  → JWT refresh token (long-lived, 7 days)
+/// - 'user_email'     → Logged-in user's email
+/// - 'user_id'        → Logged-in user's ID
+/// - 'user_name'      → Logged-in user's name
+///
+/// Platform Implementation:
+/// - iOS: Stored in Keychain (encrypted)
+/// - Android: Stored in EncryptedSharedPreferences (encrypted)
+/// - Web: localStorage (requires additional HTTPS + encryption)
+/// - macOS: Stored in Keychain (encrypted)
+///
+/// ============================================================================
+/// 3. ACCESSING TOKENS
+/// ============================================================================
+///
+/// Option A: Using TokenStorageService directly
+/// ```dart
+/// final tokenStorage = ref.watch(tokenStorageServiceProvider);
+/// final token = await tokenStorage.getAccessToken();
+/// ```
+///
+/// Option B: Using Convenience Providers
+/// ```dart
+/// final accessToken = ref.watch(accessTokenProvider);
+/// final user = ref.watch(currentUserProvider);
+/// final isLoggedIn = ref.watch(isLoggedInProvider);
+/// ```
+///
+/// Option C: Reading from AuthState
+/// ```dart
+/// final authState = ref.watch(authProvider);
+/// final user = authState.user;
+/// final token = authState.accessToken;
+/// ```
+///
+/// ============================================================================
+/// 4. USING TOKENS IN API CALLS
+/// ============================================================================
+///
+/// Automatic Injection via AuthInterceptor:
+/// File: lib/features/auth/data/services/auth_interceptor.dart
+///
+/// When making HTTP requests with authenticated Dio client:
+/// 1. Create Dio with auth interceptor: `createAuthenticatedDio(tokenStorage)`
+/// 2. Interceptor automatically:
+///    - On every request: Adds 'Authorization: Bearer <token>' header
+///    - On 401 error: Clears invalid tokens (token expired)
+///
+/// Example in API Service:
+/// ```dart
+/// final dio = createAuthenticatedDio(tokenStorage);
+/// final response = await dio.get('/protected-endpoint');
+/// // Token is automatically added to Authorization header
+/// ```
+///
+/// ============================================================================
+/// 5. CHECKING LOGIN STATUS ON APP STARTUP
+/// ============================================================================
+///
+/// In main.dart or top-level widget:
+/// ```dart
+/// @override
+/// void initState() {
+///   super.initState();
+///   Future.microtask(() {
+///     ref.read(authProvider.notifier).checkAuthStatus();
+///   });
+/// }
+/// ```
+///
+/// This method:
+/// - Reads tokens from secure storage
+/// - Checks if access token exists
+/// - Updates global auth state if logged in
+/// - Allows app to restore session on restart
+///
+/// ============================================================================
+/// 6. LOGOUT
+/// ============================================================================
+///
+/// Call logout:
+/// ```dart
+/// await ref.read(authProvider.notifier).logout();
+/// ```
+///
+/// Effects:
+/// - Calls authRepository.logout()
+/// - Deletes all tokens from secure storage
+/// - Clears global auth state
+/// - User is redirected to login screen
+///
+/// ============================================================================
+/// 7. TOKEN REFRESH (Optional - TODO)
+/// ============================================================================
+///
+/// When access token expires (401 response):
+/// Current: User must login again
+/// Recommended implementation:
+/// - Store refreshToken in secure storage (✓ already doing this)
+/// - Implement refresh endpoint: POST /api/auth/refresh-token
+/// - Create refresh interceptor to:
+///   1. Catch 401 responses
+///   2. Call refresh endpoint with refreshToken
+///   3. Save new accessToken
+///   4. Retry original request
+///
+/// ============================================================================
+/// 8. SECURITY BEST PRACTICES IMPLEMENTED
+/// ============================================================================
+///
+/// ✓ Tokens stored in encrypted secure storage (not SharedPreferences)
+/// ✓ Tokens never logged or printed to console
+/// ✓ Tokens automatically included in Authorization header
+/// ✓ 401 responses trigger token deletion
+/// ✓ Tokens cleared on logout
+/// ✓ No tokens in URL parameters
+/// ✓ No tokens in plain http://localhost (should use HTTPS in production)
+///
+/// TODO for Production:
+/// - Use HTTPS instead of HTTP
+/// - Implement token refresh mechanism
+/// - Add token expiry checking
+/// - Implement certificate pinning
+/// - Add request/response logging with token redaction
+///
+/// ============================================================================
+/// 9. DEPENDENCIES REQUIRED IN pubspec.yaml
+/// ============================================================================
+///
+/// dependencies:
+///   flutter:
+///     sdk: flutter
+///   flutter_riverpod: ^2.4.0
+///   flutter_secure_storage: ^8.0.0
+///   dio: ^5.0.0
+///
+/// ============================================================================

--- a/mobile/pezy_mobile/lib/features/auth/data/services/auth_interceptor.dart
+++ b/mobile/pezy_mobile/lib/features/auth/data/services/auth_interceptor.dart
@@ -1,0 +1,61 @@
+/// Authenticated HTTP client with automatic JWT token injection
+/// All requests made through this client will automatically include the access token
+import 'package:dio/dio.dart';
+import 'token_storage_service.dart';
+
+class AuthInterceptor extends Interceptor {
+  final TokenStorageService _tokenStorage;
+
+  AuthInterceptor(this._tokenStorage);
+
+  /// Add access token to all outgoing requests
+  @override
+  Future<void> onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) async {
+    final accessToken = await _tokenStorage.getAccessToken();
+
+    if (accessToken != null && accessToken.isNotEmpty) {
+      options.headers['Authorization'] = 'Bearer $accessToken';
+    }
+
+    return handler.next(options);
+  }
+
+  /// Handle 401 Unauthorized - token expired
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (err.response?.statusCode == 401) {
+      // Token expired or invalid
+      // TODO: Implement token refresh or redirect to login
+      await _tokenStorage.clearAll();
+    }
+
+    return handler.next(err);
+  }
+}
+
+/// Create authenticated Dio instance with token injection
+Dio createAuthenticatedDio(TokenStorageService tokenStorage) {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: 'http://localhost:3001/api',
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+      contentType: 'application/json',
+      validateStatus: (status) {
+        // Don't throw on any status code - let handlers manage them
+        return true;
+      },
+    ),
+  );
+
+  // Add auth interceptor
+  dio.interceptors.add(AuthInterceptor(tokenStorage));
+
+  return dio;
+}

--- a/mobile/pezy_mobile/lib/features/auth/presentation/pages/otp_verification_screen.dart
+++ b/mobile/pezy_mobile/lib/features/auth/presentation/pages/otp_verification_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/theme/index.dart';
 import '../controllers/otp_controller.dart';
 import '../utils/form_validation.dart';
+import '../providers/auth_provider.dart';
 
 class OtpVerificationScreen extends ConsumerStatefulWidget {
   final String email;
@@ -327,7 +328,29 @@ class _OtpVerificationScreenState extends ConsumerState<OtpVerificationScreen> {
       // Call the controller's verifyOtp method
       await otpNotifier.verifyOtp();
 
-      // On success, navigate to home/dashboard
+      // Get the updated auth state (tokens and user data are now saved)
+      final tokenStorage = ref.read(tokenStorageServiceProvider);
+      final accessToken = await tokenStorage.getAccessToken();
+      final userId = await tokenStorage.getUserId();
+      final userEmail = await tokenStorage.getUserEmail();
+      final userName = await tokenStorage.getUserName();
+
+      // Update global auth state
+      if (accessToken != null &&
+          userId != null &&
+          userEmail != null &&
+          userName != null) {
+        final authNotifier = ref.read(authProvider.notifier);
+        authNotifier.setAuthenticatedUser(
+          id: userId,
+          email: userEmail,
+          name: userName,
+          role: 'police_officer', // Default - could store actual role
+          accessToken: accessToken,
+        );
+      }
+
+      // On success, show message and navigate to home/dashboard
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -336,13 +359,16 @@ class _OtpVerificationScreenState extends ConsumerState<OtpVerificationScreen> {
           ),
         );
 
-        // TODO: Navigate to home screen
+        // TODO: Delay and navigate to home screen
         // Navigator.of(context).pushReplacementNamed('/home');
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Home screen coming soon'),
-          ),
-        );
+        await Future.delayed(const Duration(milliseconds: 500));
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Home screen coming soon'),
+            ),
+          );
+        }
       }
     } catch (e) {
       // Error is already set in the controller

--- a/mobile/pezy_mobile/lib/features/auth/presentation/providers/auth_provider.dart
+++ b/mobile/pezy_mobile/lib/features/auth/presentation/providers/auth_provider.dart
@@ -1,0 +1,235 @@
+/// Authentication state and notifier
+/// Manages the overall authentication state of the app
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../data/repositories/auth_repository.dart';
+import '../../data/services/auth_api_service.dart';
+import '../../data/services/token_storage_service.dart';
+
+/// User data model
+class AuthUser {
+  final String id;
+  final String email;
+  final String name;
+  final String role; // admin, police_officer
+  final String? department;
+  final String? phone;
+  final String? badge;
+
+  const AuthUser({
+    required this.id,
+    required this.email,
+    required this.name,
+    required this.role,
+    this.department,
+    this.phone,
+    this.badge,
+  });
+
+  /// Create from JSON
+  factory AuthUser.fromJson(Map<String, dynamic> json) {
+    return AuthUser(
+      id: json['id'] ?? '',
+      email: json['email'] ?? '',
+      name: json['name'] ?? '',
+      role: json['role'] ?? 'police_officer',
+      department: json['department'],
+      phone: json['phone'],
+      badge: json['badge'],
+    );
+  }
+
+  /// Convert to JSON
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'email': email,
+      'name': name,
+      'role': role,
+      'department': department,
+      'phone': phone,
+      'badge': badge,
+    };
+  }
+}
+
+/// Overall authentication state
+class AuthState {
+  final bool isLoading;
+  final bool isLoggedIn;
+  final AuthUser? user;
+  final String? error;
+  final String? accessToken;
+
+  const AuthState({
+    this.isLoading = false,
+    this.isLoggedIn = false,
+    this.user,
+    this.error,
+    this.accessToken,
+  });
+
+  AuthState copyWith({
+    bool? isLoading,
+    bool? isLoggedIn,
+    AuthUser? user,
+    String? error,
+    String? accessToken,
+  }) {
+    return AuthState(
+      isLoading: isLoading ?? this.isLoading,
+      isLoggedIn: isLoggedIn ?? this.isLoggedIn,
+      user: user ?? this.user,
+      error: error,
+      accessToken: accessToken ?? this.accessToken,
+    );
+  }
+}
+
+/// Authentication notifier
+class AuthNotifier extends StateNotifier<AuthState> {
+  final AuthRepository _authRepository;
+  final TokenStorageService _tokenStorage;
+
+  AuthNotifier(
+    this._authRepository,
+    this._tokenStorage,
+  ) : super(const AuthState());
+
+  /// Check if user is already logged in (on app startup)
+  Future<void> checkAuthStatus() async {
+    state = state.copyWith(isLoading: true);
+
+    try {
+      final isLoggedIn = await _authRepository.isLoggedIn();
+
+      if (isLoggedIn) {
+        final accessToken = await _tokenStorage.getAccessToken();
+        final userId = await _tokenStorage.getUserId();
+        final userEmail = await _tokenStorage.getUserEmail();
+        final userName = await _tokenStorage.getUserName();
+
+        if (accessToken != null &&
+            userId != null &&
+            userEmail != null &&
+            userName != null) {
+          final user = AuthUser(
+            id: userId,
+            email: userEmail,
+            name: userName,
+            role: 'police_officer', // Default, could be stored too
+          );
+
+          state = state.copyWith(
+            isLoading: false,
+            isLoggedIn: true,
+            user: user,
+            accessToken: accessToken,
+          );
+          return;
+        }
+      }
+
+      state = state.copyWith(
+        isLoading: false,
+        isLoggedIn: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        isLoggedIn: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Logout
+  Future<void> logout() async {
+    state = state.copyWith(isLoading: true);
+
+    try {
+      await _authRepository.logout();
+      state = const AuthState();
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Called after successful OTP verification
+  /// Updates auth state with user and tokens
+  void setAuthenticatedUser({
+    required String id,
+    required String email,
+    required String name,
+    required String role,
+    required String accessToken,
+    String? department,
+    String? phone,
+    String? badge,
+  }) {
+    final user = AuthUser(
+      id: id,
+      email: email,
+      name: name,
+      role: role,
+      department: department,
+      phone: phone,
+      badge: badge,
+    );
+
+    state = state.copyWith(
+      isLoggedIn: true,
+      user: user,
+      accessToken: accessToken,
+      error: null,
+    );
+  }
+
+  /// Clear auth state (for logout or error)
+  void clearAuth() {
+    state = const AuthState();
+  }
+}
+
+/// Providers
+
+/// Token storage service provider
+final tokenStorageServiceProvider = Provider<TokenStorageService>((ref) {
+  return TokenStorageService();
+});
+
+/// Auth repository provider
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  final tokenStorage = ref.watch(tokenStorageServiceProvider);
+  return AuthRepository(
+    apiService: AuthApiService(),
+    tokenStorage: tokenStorage,
+  );
+});
+
+/// Auth state provider
+final authProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  final authRepository = ref.watch(authRepositoryProvider);
+  final tokenStorage = ref.watch(tokenStorageServiceProvider);
+  return AuthNotifier(authRepository, tokenStorage);
+});
+
+/// Convenience provider - check if user is logged in
+final isLoggedInProvider = Provider<bool>((ref) {
+  final authState = ref.watch(authProvider);
+  return authState.isLoggedIn;
+});
+
+/// Convenience provider - get current user
+final currentUserProvider = Provider<AuthUser?>((ref) {
+  final authState = ref.watch(authProvider);
+  return authState.user;
+});
+
+/// Convenience provider - get access token
+final accessTokenProvider = Provider<String?>((ref) {
+  final authState = ref.watch(authProvider);
+  return authState.accessToken;
+});


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The code now stores JWT access tokens securely using flutter_secure_storage, rather than SharedPreferences. This change improves security by storing sensitive data in an encrypted storage. The token storage flow involves verifying OTP, saving tokens to secure storage, and updating the auth state.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-344](https://oshadadilshan.atlassian.net/browse/PEZY-344)

## Changes
- Store accessToken and refreshToken using flutter_secure_storage
- Update auth state after successful OTP verification
- Use encrypted storage for JWT tokens on iOS, Android, and macOS platforms

[PEZY-344]: https://oshadadilshan.atlassian.net/browse/PEZY-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ