### PR TITLE
PEZY-476: Web | FinePay | Build payment success page

### DIFF
--- a/frontend/src/config/routes.tsx
+++ b/frontend/src/config/routes.tsx
@@ -5,6 +5,7 @@ import Profile from '../pages/Profile'
 import Settings from '../pages/Settings'
 import NewsAwareness from '../pages/NewsAwareness'
 import FinePay from '../pages/FinePay'
+import FinePaySuccess from '../pages/FinePaySuccess'
 import CriminalRecords from '../pages/CriminalRecords'
 import CriminalRecordProfile from '../pages/CriminalRecordProfile'
 import AdminLogin from '../pages/AdminLogin'
@@ -61,6 +62,11 @@ export const routes: RouteConfig[] = [
     path: '/fine-pay',
     element: <FinePay />,
     name: 'Fine Pay',
+  },
+  {
+    path: '/fine-pay/success',
+    element: <FinePaySuccess />,
+    name: 'Fine Pay Success',
   },
   {
     path: '/admin',

--- a/frontend/src/pages/FinePay.tsx
+++ b/frontend/src/pages/FinePay.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import type { CSSProperties } from 'react'
+import { useNavigate } from 'react-router-dom'
 import NavBar from '../components/NavBar'
 import finePayBg from '../assets/slider/slide-1.png'
 import './Home.css'
 import './FinePay.css'
 
 export default function FinePay() {
+  const navigate = useNavigate()
   const [licenseNumber, setLicenseNumber] = useState('')
   const [licenseError, setLicenseError] = useState('')
 
@@ -53,6 +55,7 @@ export default function FinePay() {
     }
 
     setLicenseError('')
+    navigate('/fine-pay/success')
   }
 
   return (

--- a/frontend/src/pages/FinePaySuccess.css
+++ b/frontend/src/pages/FinePaySuccess.css
@@ -1,0 +1,142 @@
+.fine-pay-success-page {
+  padding-bottom: 0;
+}
+
+.fine-pay-success-page__content {
+  min-height: clamp(30rem, 70vh, 43rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.2rem 1rem 3rem;
+  background: linear-gradient(180deg, #dce8f8 0%, #c7d8ee 100%);
+}
+
+.fine-pay-success-card {
+  width: min(100%, 27rem);
+  text-align: center;
+}
+
+.fine-pay-success-card__icon {
+  margin: 0 auto;
+  width: 3.7rem;
+  height: 3.7rem;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #c9ecd9;
+  color: #1f9a5e;
+  font-size: 1.7rem;
+  font-weight: 700;
+}
+
+.fine-pay-success-card__icon-mark {
+  width: 0.8rem;
+  height: 1.45rem;
+  border-right: 3px solid currentColor;
+  border-bottom: 3px solid currentColor;
+  transform: rotate(40deg) translateY(-1px);
+}
+
+.fine-pay-success-card h2 {
+  margin-top: 1.2rem;
+  margin-bottom: 0;
+  color: #162339;
+  font-size: clamp(1.65rem, 3vw, 2rem);
+  font-weight: 800;
+}
+
+.fine-pay-success-card p {
+  margin: 0.7rem auto 1.4rem;
+  max-width: 23rem;
+  color: #4f647f;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.fine-pay-success-summary {
+  border-radius: 0.7rem;
+  background: #f7f7f7;
+  border-top: 4px solid #22c55e;
+  box-shadow: 0 10px 24px rgba(22, 35, 57, 0.08);
+  padding: 1.1rem 1.1rem 1rem;
+  text-align: left;
+}
+
+.fine-pay-success-summary__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #5c6f86;
+  font-size: 0.84rem;
+  padding: 0.42rem 0;
+}
+
+.fine-pay-success-summary__row span:last-child {
+  color: #26384f;
+}
+
+.fine-pay-success-summary__row--amount strong {
+  color: #162339;
+  font-size: 1.58rem;
+}
+
+.fine-pay-success-card__download {
+  margin-top: 1.2rem;
+  width: 100%;
+  min-height: 2.9rem;
+  border: 0;
+  border-radius: 0.58rem;
+  background: linear-gradient(135deg, #2093df 0%, #1b81cd 100%);
+  color: #fff;
+  font-size: 0.94rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.fine-pay-success-card__download:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(32, 147, 223, 0.32);
+}
+
+.fine-pay-success-card__download:active {
+  transform: translateY(0);
+}
+
+.fine-pay-success-card__retry {
+  margin-top: 1rem;
+  display: inline-block;
+  color: #1e5ed8;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.fine-pay-success-card__retry:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 680px) {
+  .fine-pay-success-page__content {
+    min-height: 27rem;
+    padding: 1.4rem 0.8rem 1.8rem;
+  }
+
+  .fine-pay-success-card h2 {
+    font-size: 1.45rem;
+  }
+
+  .fine-pay-success-card p {
+    font-size: 0.88rem;
+  }
+
+  .fine-pay-success-summary {
+    padding-inline: 0.9rem;
+  }
+
+  .fine-pay-success-summary__row--amount strong {
+    font-size: 1.35rem;
+  }
+}

--- a/frontend/src/pages/FinePaySuccess.tsx
+++ b/frontend/src/pages/FinePaySuccess.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import NavBar from '../components/NavBar'
+import './Home.css'
+import './FinePaySuccess.css'
+
+const formatDate = (date: Date) => {
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const year = date.getFullYear()
+  return `${month}/${day}/${year}`
+}
+
+export default function FinePaySuccess() {
+  const transactionDate = useMemo(() => formatDate(new Date()), [])
+
+  return (
+    <section className="home-police fine-pay-success-page">
+      <NavBar />
+
+      <div className="fine-pay-success-page__content">
+        <article className="fine-pay-success-card" aria-labelledby="fine-pay-success-title">
+          <div className="fine-pay-success-card__icon" aria-hidden="true">
+            <span className="fine-pay-success-card__icon-mark" />
+          </div>
+
+          <h2 id="fine-pay-success-title">Payment Successful!</h2>
+          <p>Your transaction has been completed and the selected fines have been cleared from the system.</p>
+
+          <section className="fine-pay-success-summary" aria-label="Payment summary">
+            <div className="fine-pay-success-summary__row fine-pay-success-summary__row--amount">
+              <span>Amount Paid</span>
+              <strong>LKR 6,000</strong>
+            </div>
+
+            <div className="fine-pay-success-summary__row">
+              <span>Date</span>
+              <span>{transactionDate}</span>
+            </div>
+
+            <div className="fine-pay-success-summary__row">
+              <span>Reference ID</span>
+              <span>TRX-291763</span>
+            </div>
+
+            <div className="fine-pay-success-summary__row">
+              <span>Payment Method</span>
+              <span>VISA **** 4242</span>
+            </div>
+          </section>
+
+          <button type="button" className="fine-pay-success-card__download">
+            Download Receipt (PDF)
+          </button>
+
+          <Link to="/fine-pay" className="fine-pay-success-card__retry">
+            Make Another Payment
+          </Link>
+        </article>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added a new page for payment success with a green success message, payment reference, and a Download Receipt button. The page is accessible via the /fine-pay/success route. The FinePay page now navigates to the FinePaySuccess page upon successful payment.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-476](https://oshadadilshan.atlassian.net/browse/PEZY-476)

## Changes
- Added a new route for FinePaySuccess page
- Created a new FinePaySuccess page with a green success message, payment reference, and a Download Receipt button
- Updated the FinePay page to navigate to the FinePaySuccess page upon successful payment
- Added CSS styles for the FinePaySuccess page

[PEZY-476]: https://oshadadilshan.atlassian.net/browse/PEZY-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ