### PR TITLE
PEZY-492: AdminAuthGuard route protection component

### DIFF
--- a/frontend/src/components/admin/AdminAuthGuard.tsx
+++ b/frontend/src/components/admin/AdminAuthGuard.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { authAPI } from '@/api'
+
+interface AdminAuthGuardProps {
+  children: ReactNode
+}
+
+export default function AdminAuthGuard({ children }: AdminAuthGuardProps) {
+  const location = useLocation()
+  const [isChecking, setIsChecking] = useState(true)
+  const [isAuthorized, setIsAuthorized] = useState(false)
+
+  useEffect(() => {
+    const validateAdminSession = async () => {
+      const token = localStorage.getItem('authToken')
+
+      if (!token) {
+        setIsAuthorized(false)
+        setIsChecking(false)
+        return
+      }
+
+      try {
+        const response = await authAPI.getCurrentUser()
+        const user = (response.data as { user?: { role?: string } }).user
+
+        if (user?.role === 'admin') {
+          setIsAuthorized(true)
+        } else {
+          localStorage.removeItem('authToken')
+          localStorage.removeItem('refreshToken')
+          localStorage.removeItem('adminUser')
+          setIsAuthorized(false)
+        }
+      } catch {
+        localStorage.removeItem('authToken')
+        localStorage.removeItem('refreshToken')
+        localStorage.removeItem('adminUser')
+        setIsAuthorized(false)
+      } finally {
+        setIsChecking(false)
+      }
+    }
+
+    validateAdminSession()
+  }, [location.pathname])
+
+  if (isChecking) {
+    return <div style={{ padding: '2rem', textAlign: 'center' }}>Checking admin session...</div>
+  }
+
+  if (!isAuthorized) {
+    return <Navigate to="/admin" replace state={{ from: location.pathname }} />
+  }
+
+  return <>{children}</>
+}

--- a/frontend/src/config/routes.tsx
+++ b/frontend/src/config/routes.tsx
@@ -24,7 +24,7 @@ import AdminDashboard from '../pages/AdminDashboard'
 import AdminFineManagement from '../pages/AdminFineManagement'
 import AdminCriminalRecords from '../pages/AdminCriminalRecords'
 import AdminNewsManagement from '../pages/AdminNewsManagement'
-import AdminRouteGuard from '../components/admin/AdminRouteGuard'
+import AdminAuthGuard from '../components/admin/AdminAuthGuard'
 import NotFound from '../pages/NotFound'
 
 export interface RouteConfig {
@@ -137,44 +137,44 @@ export const routes: RouteConfig[] = [
   {
     path: '/admin/dashboard',
     element: (
-      <AdminRouteGuard>
+      <AdminAuthGuard>
         <AdminLayout>
           <AdminDashboard sectionName="Dashboard" />
         </AdminLayout>
-      </AdminRouteGuard>
+      </AdminAuthGuard>
     ),
     name: 'Admin Dashboard',
   },
   {
     path: '/admin/fines',
     element: (
-      <AdminRouteGuard>
+      <AdminAuthGuard>
         <AdminLayout>
           <AdminFineManagement />
         </AdminLayout>
-      </AdminRouteGuard>
+      </AdminAuthGuard>
     ),
     name: 'Admin Fines',
   },
   {
     path: '/admin/criminal-records',
     element: (
-      <AdminRouteGuard>
+      <AdminAuthGuard>
         <AdminLayout>
           <AdminCriminalRecords />
         </AdminLayout>
-      </AdminRouteGuard>
+      </AdminAuthGuard>
     ),
     name: 'Admin Criminal Records',
   },
   {
     path: '/admin/news',
     element: (
-      <AdminRouteGuard>
+      <AdminAuthGuard>
         <AdminLayout>
           <AdminNewsManagement />
         </AdminLayout>
-      </AdminRouteGuard>
+      </AdminAuthGuard>
     ),
     name: 'Admin News',
   },


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Created a new AdminAuthGuard component to protect admin routes by validating the JWT token stored in local storage and checking the user's role. If the token is invalid or the user is not an admin, the component redirects to the login page. This component uses the authAPI to validate the token and retrieve the user's role.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-492](https://oshadadilshan.atlassian.net/browse/PEZY-492)

## Changes
- Created a new file `AdminAuthGuard.tsx` to handle admin route protection
- Implemented token validation and role checking using the authAPI
- Updated `routes.tsx` to use the new `AdminAuthGuard` component instead of `AdminRouteGuard`

[PEZY-492]: https://oshadadilshan.atlassian.net/browse/PEZY-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ