### PR TITLE
PEZY-498: Fetch Admin Dashboard Stats

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,6 +1,10 @@
 import { getSupabaseClient } from '../config/supabaseClient.js';
+import { getAllFinesForAdmin as getAllFinesForAdminService } from '../services/fineService.js';
+import { getAllCriminals as getAllCriminalsService } from '../services/criminalService.js';
 
 const stripHtml = (value) => String(value || '').replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+
+const formatCount = (value) => new Intl.NumberFormat('en-US').format(Number(value || 0));
 
 export const getAllNewsForAdmin = async (req, res, next) => {
   try {
@@ -58,6 +62,127 @@ export const getAllNewsForAdmin = async (req, res, next) => {
       success: true,
       news,
       total: news.length,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getDashboardStatsForAdmin = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+    const now = new Date();
+
+    let fineRecords = [];
+    let criminalRecordsList = [];
+    let newsRows = [];
+
+    try {
+      fineRecords = await getAllFinesForAdminService();
+    } catch (error) {
+      console.error('Failed to load admin fines for dashboard stats:', error.message);
+    }
+
+    try {
+      const criminalResult = await getAllCriminalsService({ limit: 1000, offset: 0 });
+      criminalRecordsList = criminalResult.criminals || [];
+    } catch (error) {
+      console.error('Failed to load admin criminals for dashboard stats:', error.message);
+    }
+
+    try {
+      const newsRowsResult = await supabase
+        .from('news')
+        .select('*')
+        .order('published_at', { ascending: false })
+        .order('created_at', { ascending: false });
+
+      if (newsRowsResult.error) {
+        throw newsRowsResult.error;
+      }
+
+      newsRows = newsRowsResult.data || [];
+    } catch (error) {
+      console.error('Failed to load admin news for dashboard stats:', error.message);
+    }
+
+    const sevenDaysAgo = new Date(now);
+    sevenDaysAgo.setUTCDate(sevenDaysAgo.getUTCDate() - 7);
+    const thirtyDaysAgo = new Date(now);
+    thirtyDaysAgo.setUTCDate(thirtyDaysAgo.getUTCDate() - 30);
+
+    const totalFines = fineRecords.length;
+    const criminalRecords = criminalRecordsList.length;
+    const activeCases = fineRecords.filter((fine) => fine.status !== 'paid').length;
+    const newsPublished = newsRows.filter((row) => (row.status || (row.published_at ? 'published' : 'draft')) === 'published').length;
+    const finesThisWeek = fineRecords.filter((fine) => {
+      const createdAt = fine.date ? new Date(fine.date) : fine.created_at ? new Date(fine.created_at) : null;
+      return createdAt && !Number.isNaN(createdAt.getTime()) && createdAt >= sevenDaysAgo;
+    }).length;
+    const newRecords = criminalRecordsList.filter((criminal) => {
+      const createdAt = criminal.created_at ? new Date(criminal.created_at) : null;
+      return createdAt && !Number.isNaN(createdAt.getTime()) && createdAt >= thirtyDaysAgo;
+    }).length;
+    const wantedCriminals = criminalRecordsList.filter((criminal) => Boolean(criminal.wanted)).length;
+
+    const cards = [
+      {
+        id: 'totalFines',
+        title: 'Total Fines',
+        value: formatCount(totalFines),
+        trend: 'Live',
+        trendPositive: true,
+        tone: 'blue',
+      },
+      {
+        id: 'criminalRecords',
+        title: 'Criminal Records',
+        value: formatCount(criminalRecords),
+        trend: 'Live',
+        trendPositive: true,
+        tone: 'red',
+      },
+      {
+        id: 'activeCases',
+        title: 'Active Cases',
+        value: formatCount(activeCases),
+        trend: 'Live',
+        trendPositive: false,
+        tone: 'yellow',
+      },
+      {
+        id: 'newsPublished',
+        title: 'News Published',
+        value: formatCount(newsPublished),
+        trend: 'Live',
+        trendPositive: true,
+        tone: 'green',
+      },
+    ];
+
+    const quickStats = [
+      { label: 'Avg Fines/Week', value: formatCount(finesThisWeek), tone: 'blue' },
+      { label: 'Pending Cases', value: formatCount(activeCases), tone: 'red' },
+      { label: 'New Records', value: formatCount(newRecords), tone: 'yellow' },
+      { label: 'Wanted Criminals', value: formatCount(wantedCriminals), tone: 'green' },
+    ];
+
+    return res.status(200).json({
+      success: true,
+      stats: {
+        cards,
+        quickStats,
+        summary: {
+          totalFines,
+          criminalRecords,
+          activeCases,
+          newsPublished,
+          finesThisWeek,
+          newRecords,
+          wantedCriminals,
+        },
+        generatedAt: now.toISOString(),
+      },
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -3,7 +3,7 @@ import { authenticate } from '../middlewares/authenticate.js';
 import { authorize } from '../middlewares/authorize.js';
 import { getAllFinesForAdmin } from '../controllers/fineController.js';
 import { getAllCriminalsForAdmin } from '../controllers/criminalController.js';
-import { getAllNewsForAdmin } from '../controllers/adminController.js';
+import { getAllNewsForAdmin, getDashboardStatsForAdmin } from '../controllers/adminController.js';
 
 const router = express.Router();
 
@@ -13,5 +13,6 @@ router.use(authorize('admin'));
 router.get('/fines', getAllFinesForAdmin);
 router.get('/criminals', getAllCriminalsForAdmin);
 router.get('/news', getAllNewsForAdmin);
+router.get('/stats', getDashboardStatsForAdmin);
 
 export default router;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -10,6 +10,7 @@ import type {
   UserListResponse,
   UpdateProfileRequest,
   DashboardStats,
+  AdminDashboardStats,
   ChartData,
   AnalyticsPeriod,
 } from '@/types'
@@ -82,6 +83,8 @@ export const adminAPI = {
   getAllCriminals: () => axiosInstance.get('/admin/criminals'),
 
   getAllNews: () => axiosInstance.get('/admin/news'),
+
+  getStats: () => axiosInstance.get<{ success: boolean; stats: AdminDashboardStats }>('/admin/stats'),
 }
 
 export default axiosInstance

--- a/frontend/src/components/admin/AdminStatCards.tsx
+++ b/frontend/src/components/admin/AdminStatCards.tsx
@@ -1,73 +1,107 @@
-import type { ReactNode } from 'react'
 import './AdminStatCards.css'
 
 interface StatCard {
+  id: string
   title: string
   value: string
   trend: string
   trendPositive: boolean
   tone: 'blue' | 'red' | 'yellow' | 'green'
-  icon: ReactNode
 }
 
-const statCards: StatCard[] = [
+const defaultCards: StatCard[] = [
   {
+    id: 'totalFines',
     title: 'Total Fines',
-    value: '1,247',
-    trend: '+12.5%',
+    value: '0',
+    trend: 'Live',
     trendPositive: true,
     tone: 'blue',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M5 19h14v2H5v-2Zm1-2h2V9H6v8Zm5 0h2V5h-2v12Zm5 0h2v-6h-2v6Z" fill="currentColor" />
-      </svg>
-    ),
   },
   {
+    id: 'criminalRecords',
     title: 'Criminal Records',
-    value: '856',
-    trend: '+8.2%',
+    value: '0',
+    trend: 'Live',
     trendPositive: true,
     tone: 'red',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M9 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm6 1a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0 2c-1.8 0-3.3.8-4.2 2.1A5.6 5.6 0 0 0 5 21h2a3.6 3.6 0 0 1 3.5-3h2c1.7 0 3.1.7 4.1 2H19a4 4 0 0 0-4-6ZM9 13a6 6 0 0 0-6 6h2a4 4 0 0 1 4-4h1.2a6.2 6.2 0 0 1 2.6-2H9Z" fill="currentColor" />
-      </svg>
-    ),
   },
   {
+    id: 'activeCases',
     title: 'Active Cases',
-    value: '342',
-    trend: '-4.1%',
+    value: '0',
+    trend: 'Live',
     trendPositive: false,
     tone: 'yellow',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M6 3h9l5 5v13H6V3Zm2 2v14h10V9h-4V5H8Zm2 6h6v2h-6v-2Zm0 4h6v2h-6v-2Z" fill="currentColor" />
-      </svg>
-    ),
   },
   {
+    id: 'newsPublished',
     title: 'News Published',
-    value: '47',
-    trend: '+5.3%',
+    value: '0',
+    trend: 'Live',
     trendPositive: true,
     tone: 'green',
-    icon: (
-      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-        <path d="M4 4h14v14H4V4Zm2 2v10h10V6H6Zm2 2h6v2H8V8Zm0 4h6v2H8v-2Zm11-4h1v8a2 2 0 0 1-2 2h-1v-2h1V8Z" fill="currentColor" />
-      </svg>
-    ),
   },
 ]
 
-export default function AdminStatCards() {
+interface AdminStatCardsProps {
+  cards?: StatCard[]
+  isLoading?: boolean
+}
+
+const getIconForCard = (cardId: string) => {
+  switch (cardId) {
+    case 'criminalRecords':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M9 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm6 1a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm0 2c-1.8 0-3.3.8-4.2 2.1A5.6 5.6 0 0 0 5 21h2a3.6 3.6 0 0 1 3.5-3h2c1.7 0 3.1.7 4.1 2H19a4 4 0 0 0-4-6ZM9 13a6 6 0 0 0-6 6h2a4 4 0 0 1 4-4h1.2a6.2 6.2 0 0 1 2.6-2H9Z" fill="currentColor" />
+        </svg>
+      )
+    case 'activeCases':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M6 3h9l5 5v13H6V3Zm2 2v14h10V9h-4V5H8Zm2 6h6v2h-6v-2Zm0 4h6v2h-6v-2Z" fill="currentColor" />
+        </svg>
+      )
+    case 'newsPublished':
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M4 4h14v14H4V4Zm2 2v10h10V6H6Zm2 2h6v2H8V8Zm0 4h6v2H8v-2Zm11-4h1v8a2 2 0 0 1-2 2h-1v-2h1V8Z" fill="currentColor" />
+        </svg>
+      )
+    default:
+      return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M5 19h14v2H5v-2Zm1-2h2V9H6v8Zm5 0h2V5h-2v12Zm5 0h2v-6h-2v6Z" fill="currentColor" />
+        </svg>
+      )
+  }
+}
+
+export default function AdminStatCards({ cards = defaultCards, isLoading = false }: AdminStatCardsProps) {
+  if (isLoading) {
+    return (
+      <section className="admin-dashboard__stats-grid" aria-label="Summary statistics loading">
+        {defaultCards.map(card => (
+          <article key={card.id} className="admin-dashboard__stat-card" aria-busy="true">
+            <div className="admin-dashboard__stat-top">
+              <span className={`admin-dashboard__stat-icon is-${card.tone}`}>{getIconForCard(card.id)}</span>
+              <span className="admin-dashboard__stat-trend is-negative">Loading</span>
+            </div>
+            <p className="admin-dashboard__stat-title">{card.title}</p>
+            <p className="admin-dashboard__stat-value">&mdash;</p>
+          </article>
+        ))}
+      </section>
+    )
+  }
+
   return (
     <section className="admin-dashboard__stats-grid" aria-label="Summary statistics">
-      {statCards.map(card => (
-        <article key={card.title} className="admin-dashboard__stat-card">
+      {cards.map(card => (
+        <article key={card.id} className="admin-dashboard__stat-card">
           <div className="admin-dashboard__stat-top">
-            <span className={`admin-dashboard__stat-icon is-${card.tone}`}>{card.icon}</span>
+            <span className={`admin-dashboard__stat-icon is-${card.tone}`}>{getIconForCard(card.id)}</span>
             <span
               className={`admin-dashboard__stat-trend${
                 card.trendPositive ? ' is-positive' : ' is-negative'

--- a/frontend/src/pages/AdminDashboard.css
+++ b/frontend/src/pages/AdminDashboard.css
@@ -5,6 +5,13 @@
   font-weight: 700;
 }
 
+.admin-dashboard__error {
+  margin: 0 0 14px;
+  color: #b42318;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
 .admin-dashboard__activity-list {
   display: grid;
 }

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { adminAPI } from '@/api'
+import type { AdminDashboardStats } from '@/types'
 import AdminMainContent from '../layouts/AdminMainContent'
 import AdminStatCards from '../components/admin/AdminStatCards'
 import './AdminDashboard.css'
@@ -71,7 +73,52 @@ const quickStats: QuickStat[] = [
 ]
 
 export default function AdminDashboard({ sectionName = 'Dashboard' }: AdminDashboardProps) {
-  const topSection = <AdminStatCards />
+  const [stats, setStats] = useState<AdminDashboardStats | null>(null)
+  const [isStatsLoading, setIsStatsLoading] = useState(true)
+  const [statsError, setStatsError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadStats = async () => {
+      try {
+        setIsStatsLoading(true)
+        setStatsError(null)
+
+        const response = await adminAPI.getStats()
+
+        if (!isMounted) {
+          return
+        }
+
+        setStats(response.data.stats)
+      } catch (error) {
+        if (!isMounted) {
+          return
+        }
+
+        console.error('Failed to fetch admin dashboard stats:', error)
+        setStatsError('Unable to load dashboard stats right now.')
+      } finally {
+        if (isMounted) {
+          setIsStatsLoading(false)
+        }
+      }
+    }
+
+    loadStats()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const topSection = (
+    <div>
+      {statsError ? <p className="admin-dashboard__error">{statsError}</p> : null}
+      <AdminStatCards cards={stats?.cards} isLoading={isStatsLoading} />
+    </div>
+  )
 
   const primarySection = (
     <>
@@ -95,7 +142,7 @@ export default function AdminDashboard({ sectionName = 'Dashboard' }: AdminDashb
     <>
       <h3 className="admin-dashboard__panel-title">Quick Stats</h3>
       <div className="admin-dashboard__quick-stats">
-        {quickStats.map(item => (
+        {(stats?.quickStats || quickStats).map(item => (
           <article key={item.label} className={`admin-dashboard__quick-item is-${item.tone}`}>
             <span>{item.label}</span>
             <strong>{item.value}</strong>

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -12,6 +12,36 @@ export interface DashboardStats {
   averageSessionDuration: number
 }
 
+export interface AdminDashboardStatCard {
+  id: 'totalFines' | 'criminalRecords' | 'activeCases' | 'newsPublished' | string
+  title: string
+  value: string
+  trend: string
+  trendPositive: boolean
+  tone: 'blue' | 'red' | 'yellow' | 'green'
+}
+
+export interface AdminDashboardQuickStat {
+  label: string
+  value: string
+  tone: 'blue' | 'red' | 'yellow' | 'green'
+}
+
+export interface AdminDashboardStats {
+  cards: AdminDashboardStatCard[]
+  quickStats: AdminDashboardQuickStat[]
+  summary: {
+    totalFines: number
+    criminalRecords: number
+    activeCases: number
+    newsPublished: number
+    finesThisWeek: number
+    newRecords: number
+    wantedCriminals: number
+  }
+  generatedAt: string
+}
+
 /** Chart data point */
 export interface ChartDataPoint {
   label: string


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
The code now fetches stats on page load, shows skeleton loaders, and populates cards with totalFines, criminalRecords, activeCases, and newsPublished. The getDashboardStatsForAdmin function is added to handle this functionality. It retrieves data from various services and formats the count using the Intl.NumberFormat function.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-498](https://oshadadilshan.atlassian.net/browse/PEZY-498)

## Changes
- Added getDashboardStatsForAdmin function to handle fetching stats
- Imported fineService and criminalService to retrieve data
- Formatted count using Intl.NumberFormat function
- Retrieved news data from supabase and filtered published news

[PEZY-498]: https://oshadadilshan.atlassian.net/browse/PEZY-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ