### PR TITLE
PEZY-486: Install and configure Tailwind CSS in admin portal

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,7 @@ Admin portal frontend built with React, Vite, and TypeScript.
 - TypeScript 5
 - React Router
 - Axios
+- Tailwind CSS 4
 
 ## Prerequisites
 
@@ -71,3 +72,21 @@ npm run preview
 - `src/api` — axios instance and API wrappers
 - `src/config` — route and app config
 - `src/types` — TypeScript interfaces
+
+## Tailwind CSS (Admin Portal)
+
+Tailwind is installed and configured with PostCSS.
+
+Configuration files:
+
+- `tailwind.config.js`
+- `postcss.config.js`
+- `src/index.css`
+- `src/styles/admin-tailwind.css`
+
+Admin Tailwind layer:
+
+- `src/styles/admin-tailwind.css` defines admin-specific Tailwind component classes.
+- It is imported in `src/layouts/AdminLayout.tsx` and applied to the admin shell/sidebar/content.
+
+If you add a new admin page, prefer Tailwind utility classes or the reusable classes in `src/styles/admin-tailwind.css`.

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import Swal from 'sweetalert2'
 import { authAPI } from '@/api'
+import '../styles/admin-tailwind.css'
 import './AdminLayout.css'
 
 interface AdminLayoutProps {
@@ -106,8 +107,8 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
   }
 
   return (
-    <section className="admin-shell" aria-label="Admin dashboard layout">
-      <aside className="admin-shell__sidebar">
+    <section className="admin-shell admin-tw-shell" aria-label="Admin dashboard layout">
+      <aside className="admin-shell__sidebar admin-tw-sidebar">
         <div className="admin-shell__brand">
           <div className="admin-shell__brand-badge" aria-hidden="true">
             <svg viewBox="0 0 24 24" role="presentation" focusable="false">
@@ -163,7 +164,7 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
         </button>
       </aside>
 
-      <div className="admin-shell__content">{children}</div>
+      <div className="admin-shell__content admin-tw-content">{children}</div>
     </section>
   )
 }

--- a/frontend/src/styles/admin-tailwind.css
+++ b/frontend/src/styles/admin-tailwind.css
@@ -1,0 +1,42 @@
+@layer base {
+  :root {
+    --admin-bg: #f3f6fb;
+    --admin-surface: #ffffff;
+    --admin-sidebar: #213864;
+    --admin-sidebar-accent: #2ea6ea;
+    --admin-text: #2f3642;
+    --admin-muted: #6b7280;
+  }
+}
+
+@layer components {
+  .admin-tw-shell {
+    min-height: 100vh;
+    background: #f1f5f9;
+  }
+
+  .admin-tw-sidebar {
+    border-right: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+  }
+
+  .admin-tw-content {
+    color: #1f2937;
+  }
+
+  .admin-tw-panel {
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  }
+
+  .admin-tw-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+  }
+}


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Installed and configured Tailwind CSS in the admin portal with a dark navy sidebar and blue primary color scheme. The configuration includes PostCSS and defines admin-specific Tailwind component classes. The changes are reflected in the updated README and new CSS files.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-486](https://oshadadilshan.atlassian.net/browse/PEZY-486)

## Changes
- Added Tailwind CSS 4 to the project
- Created `tailwind.config.js`, `postcss.config.js`, and `src/styles/admin-tailwind.css` files
- Updated `src/layouts/AdminLayout.tsx` to use the new Tailwind classes
- Imported `admin-tailwind.css` in `AdminLayout.tsx`

[PEZY-486]: https://oshadadilshan.atlassian.net/browse/PEZY-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ