### PR TITLE
PEZY-487: Configure React Router for admin routes

### DIFF
--- a/frontend/src/config/adminRoutes.tsx
+++ b/frontend/src/config/adminRoutes.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import AdminLogin from '../pages/AdminLogin'
+import AdminLayout from '../layouts/AdminLayout'
+import AdminDashboard from '../pages/AdminDashboard'
+import AdminFineManagement from '../pages/AdminFineManagement'
+import AdminCriminalRecords from '../pages/AdminCriminalRecordsLive'
+import AdminNewsManagement from '../pages/AdminNewsManagement'
+import AdminAuthGuard from '../components/admin/AdminAuthGuard'
+
+export interface AdminRouteConfig {
+  path: string
+  element: ReactNode
+  name: string
+}
+
+const withAdminGuard = (page: ReactNode) => (
+  <AdminAuthGuard>
+    <AdminLayout>{page}</AdminLayout>
+  </AdminAuthGuard>
+)
+
+export const adminRoutes: AdminRouteConfig[] = [
+  {
+    path: '/admin',
+    element: <AdminLogin />,
+    name: 'Admin Login',
+  },
+  {
+    path: '/admin/dashboard',
+    element: withAdminGuard(<AdminDashboard sectionName="Dashboard" />),
+    name: 'Admin Dashboard',
+  },
+  {
+    path: '/admin/fines',
+    element: withAdminGuard(<AdminFineManagement />),
+    name: 'Admin Fines',
+  },
+  {
+    path: '/admin/criminal-records',
+    element: withAdminGuard(<AdminCriminalRecords />),
+    name: 'Admin Criminal Records',
+  },
+  {
+    path: '/admin/news',
+    element: withAdminGuard(<AdminNewsManagement />),
+    name: 'Admin News',
+  },
+]

--- a/frontend/src/config/routes.tsx
+++ b/frontend/src/config/routes.tsx
@@ -18,13 +18,7 @@ import FieldForceHeadquarters from '../pages/divisions/FieldForceHeadquarters'
 import MountedDivision from '../pages/divisions/MountedDivision'
 import PoliceCadetDivision from '../pages/divisions/PoliceCadetDivision'
 import TrafficRoadSafetyDivision from '../pages/divisions/TrafficRoadSafetyDivision'
-import AdminLogin from '../pages/AdminLogin'
-import AdminLayout from '../layouts/AdminLayout'
-import AdminDashboard from '../pages/AdminDashboard'
-import AdminFineManagement from '../pages/AdminFineManagement'
-import AdminCriminalRecords from '../pages/AdminCriminalRecordsLive'
-import AdminNewsManagement from '../pages/AdminNewsManagement'
-import AdminAuthGuard from '../components/admin/AdminAuthGuard'
+import { adminRoutes } from './adminRoutes'
 import NotFound from '../pages/NotFound'
 
 export interface RouteConfig {
@@ -129,55 +123,7 @@ export const routes: RouteConfig[] = [
     element: <FinePayFailure />,
     name: 'Fine Pay Failure',
   },
-  {
-    path: '/admin',
-    element: <AdminLogin />,
-    name: 'Admin Login',
-  },
-  {
-    path: '/admin/dashboard',
-    element: (
-      <AdminAuthGuard>
-        <AdminLayout>
-          <AdminDashboard sectionName="Dashboard" />
-        </AdminLayout>
-      </AdminAuthGuard>
-    ),
-    name: 'Admin Dashboard',
-  },
-  {
-    path: '/admin/fines',
-    element: (
-      <AdminAuthGuard>
-        <AdminLayout>
-          <AdminFineManagement />
-        </AdminLayout>
-      </AdminAuthGuard>
-    ),
-    name: 'Admin Fines',
-  },
-  {
-    path: '/admin/criminal-records',
-    element: (
-      <AdminAuthGuard>
-        <AdminLayout>
-          <AdminCriminalRecords />
-        </AdminLayout>
-      </AdminAuthGuard>
-    ),
-    name: 'Admin Criminal Records',
-  },
-  {
-    path: '/admin/news',
-    element: (
-      <AdminAuthGuard>
-        <AdminLayout>
-          <AdminNewsManagement />
-        </AdminLayout>
-      </AdminAuthGuard>
-    ),
-    name: 'Admin News',
-  },
+  ...adminRoutes,
   {
     path: '/*',
     element: <NotFound />,


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Configured React Router for admin routes, including routes for login, dashboard, fines, criminal records, and news. The non-login routes are wrapped in the AdminAuthGuard for authentication. A new file, adminRoutes.tsx, was created to manage the admin routes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-487](https://oshadadilshan.atlassian.net/browse/PEZY-487)

## Changes
- Created a new file, adminRoutes.tsx, to manage admin routes
- Defined the admin routes, including /admin, /admin/dashboard, /admin/fines, /admin/criminal-records, and /admin/news
- Wrapped non-login routes in the AdminAuthGuard for authentication

[PEZY-487]: https://oshadadilshan.atlassian.net/browse/PEZY-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ