### PR TITLE
PEZY-488: Admin Setup - Create Axios instance with auth interceptor

### DIFF
--- a/frontend/src/api/README.md
+++ b/frontend/src/api/README.md
@@ -8,9 +8,10 @@ This folder contains the HTTP client setup for your React application using axio
 The main axios instance with:
 - **Base URL**: Automatically configured from `VITE_API_BASE_URL` environment variable
 - **Default Timeout**: 10 seconds
-- **Request Interceptor**: Automatically adds Bearer token to requests if available
+- **Request Interceptor**: Automatically adds Bearer token using `VITE_AUTH_TOKEN_KEY` (defaults to `authToken`)
 - **Response Interceptor**: Handles errors with status-specific logic:
-  - `401`: Clears auth token and redirects to `/login`
+  - `401`: Clears auth storage and redirects to `/admin` for protected routes
+  - `401` on auth challenge endpoints: no redirect (`/auth/login`, `/auth/admin-login`, `/auth/admin-request-otp`, `/auth/verify-otp`)
   - `403`: Logs forbidden error
   - `404`: Logs not found error
   - `500`: Logs server error
@@ -28,7 +29,8 @@ All endpoints include TypeScript types for request/response data.
 
 ### 1. Set up environment variables (`.env`)
 ```
-VITE_API_BASE_URL=http://localhost:5000/api
+VITE_API_BASE_URL=http://localhost:8000/api
+VITE_AUTH_TOKEN_KEY=authToken
 ```
 
 ### 2. Use API service functions directly
@@ -70,9 +72,10 @@ const data = await axiosInstance.post('/custom-endpoint', { /* data */ })
 
 The axios instance automatically handles Bearer token authentication:
 
-1. When a login request succeeds, store the token:
+1. When a login request succeeds, store the token with the configured key:
    ```typescript
-   localStorage.setItem('authToken', token)
+  const tokenKey = import.meta.env.VITE_AUTH_TOKEN_KEY || 'authToken'
+  localStorage.setItem(tokenKey, token)
    ```
 
 2. The request interceptor automatically adds it to all requests:
@@ -80,7 +83,7 @@ The axios instance automatically handles Bearer token authentication:
    Authorization: Bearer <token>
    ```
 
-3. If a 401 response is received, the error interceptor clears the token and redirects to login.
+3. If a 401 response is received for a protected route, the error interceptor clears auth storage and redirects to `/admin`.
 
 ## Error Handling
 

--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -3,6 +3,15 @@ import type { InternalAxiosRequestConfig } from 'axios'
 
 // Get base URL from environment or use default
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api'
+const AUTH_TOKEN_KEY = import.meta.env.VITE_AUTH_TOKEN_KEY || 'authToken'
+const REFRESH_TOKEN_KEY = 'refreshToken'
+const ADMIN_USER_KEY = 'adminUser'
+
+const clearAuthStorage = () => {
+  localStorage.removeItem(AUTH_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+  localStorage.removeItem(ADMIN_USER_KEY)
+}
 
 // Create axios instance
 const axiosInstance = axios.create({
@@ -17,7 +26,7 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     // Add auth token if available
-    const token = localStorage.getItem('authToken')
+    const token = localStorage.getItem(AUTH_TOKEN_KEY)
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
@@ -40,15 +49,14 @@ axiosInstance.interceptors.response.use(
       const isAuthChallengeRequest =
         requestUrl.includes('/auth/admin-login') ||
         requestUrl.includes('/auth/admin-request-otp') ||
-        requestUrl.includes('/auth/verify-otp')
+        requestUrl.includes('/auth/verify-otp') ||
+        requestUrl.includes('/auth/login')
 
       switch (error.response.status) {
         case 401: {
           // Don't force redirect on failed login attempts.
           if (!isAuthChallengeRequest) {
-            localStorage.removeItem('authToken')
-            localStorage.removeItem('refreshToken')
-            localStorage.removeItem('adminUser')
+            clearAuthStorage()
             window.location.href = '/admin'
           }
           break


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Created an Axios instance with a base URL and added a request interceptor to automatically attach a JWT token from local storage. The instance also includes a response interceptor to handle errors, including a 401 interceptor that clears auth storage and redirects to /admin for protected routes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-488](https://oshadadilshan.atlassian.net/browse/PEZY-488)

## Changes
- Added a request interceptor to automatically add a Bearer token to requests using the VITE_AUTH_TOKEN_KEY
- Updated the response interceptor to clear auth storage and redirect to /admin on 401 errors for protected routes
- Modified environment variables to include VITE_API_BASE_URL and VITE_AUTH_TOKEN_KEY

[PEZY-488]: https://oshadadilshan.atlassian.net/browse/PEZY-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ