### PR TITLE
PEZY-441: Create adminFineRoutes.js

### DIFF
--- a/backend/src/controllers/fineController.js
+++ b/backend/src/controllers/fineController.js
@@ -3,6 +3,7 @@ import {
   getFineById as getFineByIdService,
   getFinesByLicense as getFinesByLicenseService,
   getAllFinesForAdmin as getAllFinesForAdminService,
+  getFineByIdForAdmin as getFineByIdForAdminService,
   updateFineForAdmin as updateFineForAdminService,
   deleteFineForAdmin as deleteFineForAdminService,
   getOutdatedFines as getOutdatedFinesService,
@@ -90,6 +91,24 @@ export const getAllFinesForAdmin = async (req, res, next) => {
     return res.status(200).json({
       success: true,
       fines,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Get a fine by ID from admin panel
+ * GET /api/admin/fines/:fineId
+ */
+export const getFineByIdForAdmin = async (req, res, next) => {
+  try {
+    const { fineId } = req.params;
+    const fine = await getFineByIdForAdminService(fineId);
+
+    return res.status(200).json({
+      success: true,
+      fine,
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/adminFineRoutes.js
+++ b/backend/src/routes/adminFineRoutes.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import {
+  getAllFinesForAdmin,
+  getFineByIdForAdmin,
+  updateFineForAdmin,
+  deleteFineForAdmin,
+} from '../controllers/fineController.js';
+
+const router = express.Router();
+
+// GET /api/admin/fines
+router.get('/', getAllFinesForAdmin);
+
+// GET /api/admin/fines/:fineId
+router.get('/:fineId', getFineByIdForAdmin);
+
+// PUT /api/admin/fines/:fineId
+router.put('/:fineId', updateFineForAdmin);
+
+// Backward compatible update endpoint
+router.patch('/:fineId', updateFineForAdmin);
+
+// DELETE /api/admin/fines/:fineId
+router.delete('/:fineId', deleteFineForAdmin);
+
+export default router;

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { authenticate } from '../middlewares/authenticate.js';
 import { authorize } from '../middlewares/authorize.js';
-import { getAllFinesForAdmin, updateFineForAdmin, deleteFineForAdmin } from '../controllers/fineController.js';
+import adminFineRoutes from './adminFineRoutes.js';
 import { getAllCriminalsForAdmin } from '../controllers/criminalController.js';
 import { getAllNewsForAdmin, getDashboardStatsForAdmin } from '../controllers/adminController.js';
 
@@ -10,9 +10,7 @@ const router = express.Router();
 router.use(authenticate);
 router.use(authorize('admin'));
 
-router.get('/fines', getAllFinesForAdmin);
-router.patch('/fines/:fineId', updateFineForAdmin);
-router.delete('/fines/:fineId', deleteFineForAdmin);
+router.use('/fines', adminFineRoutes);
 router.get('/criminals', getAllCriminalsForAdmin);
 router.get('/news', getAllNewsForAdmin);
 router.get('/stats', getDashboardStatsForAdmin);

--- a/backend/src/services/fineService.js
+++ b/backend/src/services/fineService.js
@@ -304,6 +304,52 @@ export const getAllFinesForAdmin = async () => {
   });
 };
 
+export const getFineByIdForAdmin = async (fineId) => {
+  if (!fineId) {
+    throw new ValidationError('fineId is required');
+  }
+
+  const supabase = getSupabaseClient();
+
+  const { data: fine, error } = await supabase
+    .from('fines')
+    .select(`
+      id,
+      amount,
+      reason,
+      status,
+      issue_date,
+      due_date,
+      created_at,
+      driver_id,
+      drivers(first_name, last_name)
+    `)
+    .eq('id', fineId)
+    .single();
+
+  if (error || !fine) {
+    throw new NotFoundError('Fine not found');
+  }
+
+  const todayIso = new Date().toISOString().split('T')[0];
+  const isPaid = fine.status === 'paid';
+  const isOverdue = !isPaid && fine.due_date && fine.due_date < todayIso;
+  const normalizedStatus = isPaid ? 'paid' : isOverdue ? 'overdue' : 'pending';
+  const driver = fine.drivers || {};
+
+  return {
+    id: fine.id,
+    offender: `${driver.first_name || ''} ${driver.last_name || ''}`.trim() || 'Unknown Driver',
+    violation: fine.reason || 'N/A',
+    amount: Number(fine.amount || 0),
+    date: fine.issue_date || (fine.created_at ? fine.created_at.split('T')[0] : null),
+    status: normalizedStatus,
+    raw_status: fine.status,
+    due_date: fine.due_date,
+    driver_id: fine.driver_id,
+  };
+};
+
 const normalizeAdminFineStatus = (status) => {
   if (status === 'paid') {
     return { dbStatus: 'paid', dueDate: null };


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Created a new route file called adminFineRoutes.js to handle fine-related operations for admins. This includes GET, PUT, and DELETE endpoints for /api/admin/fines. The new endpoints allow admins to view, edit, and soft delete fines.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-441](https://oshadadilshan.atlassian.net/browse/PEZY-441)

## Changes
- Added a new file adminFineRoutes.js to handle fine-related routes for admins
- Implemented GET /api/admin/fines to retrieve all fines for admins
- Implemented GET /api/admin/fines/:fineId to retrieve a fine by ID for admins
- Implemented PUT /api/admin/fines/:fineId to update a fine for admins
- Implemented DELETE /api/admin/fines/:fineId to soft delete a fine for admins

[PEZY-441]: https://oshadadilshan.atlassian.net/browse/PEZY-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ