### PR TITLE
PEZY-444: Admin Officer Routes

### DIFF
--- a/backend/src/controllers/officerController.js
+++ b/backend/src/controllers/officerController.js
@@ -1,4 +1,24 @@
 import { getSupabaseClient } from '../config/supabaseClient.js';
+import { AppError, ConflictError, NotFoundError, ValidationError } from '../utils/errors.js';
+
+const mapOfficer = (officer) => ({
+  id: officer.id,
+  name: officer.name,
+  email: officer.email,
+  phone: officer.phone,
+  role: officer.role,
+  badge_number: officer.badge_number,
+  department: officer.department,
+  rank: officer.rank,
+  status: officer.status,
+  is_online: officer.is_online,
+  is_verified: officer.is_verified,
+  phone_verified: officer.phone_verified,
+  last_login_at: officer.last_login_at,
+  last_logout_at: officer.last_logout_at,
+  created_at: officer.created_at,
+  updated_at: officer.updated_at,
+});
 
 /**
  * Get all currently online police officers
@@ -144,6 +164,219 @@ export const getOfficerStatus = async (req, res, next) => {
         last_login_at: officer.last_login_at,
         last_logout_at: officer.last_logout_at,
       },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Get all officers for admin
+ * GET /api/admin/officers
+ */
+export const getAllOfficersAdmin = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+
+    const { data: officers, error } = await supabase
+      .from('users')
+      .select('*')
+      .eq('role', 'police_officer')
+      .order('name', { ascending: true });
+
+    if (error) {
+      throw new AppError(`Failed to fetch officers: ${error.message}`, 500);
+    }
+
+    return res.status(200).json({
+      success: true,
+      officers: (officers || []).map(mapOfficer),
+      total: officers?.length || 0,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Get officer by ID for admin
+ * GET /api/admin/officers/:officerId
+ */
+export const getOfficerByIdAdmin = async (req, res, next) => {
+  try {
+    const { officerId } = req.params;
+
+    const supabase = getSupabaseClient();
+    const { data: officer, error } = await supabase
+      .from('users')
+      .select('*')
+      .eq('id', officerId)
+      .eq('role', 'police_officer')
+      .single();
+
+    if (error || !officer) {
+      throw new NotFoundError('Officer not found');
+    }
+
+    return res.status(200).json({
+      success: true,
+      officer: mapOfficer(officer),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Create officer for admin
+ * POST /api/admin/officers
+ */
+export const createOfficerAdmin = async (req, res, next) => {
+  try {
+    const name = String(req.body?.name || '').trim();
+    const phone = String(req.body?.phone || '').trim();
+
+    if (!name) {
+      throw new ValidationError('name is required');
+    }
+
+    if (!phone) {
+      throw new ValidationError('phone is required');
+    }
+
+    const supabase = getSupabaseClient();
+
+    const payload = {
+      name,
+      phone,
+      email: req.body?.email || null,
+      role: 'police_officer',
+      badge_number: req.body?.badge_number || null,
+      department: req.body?.department || null,
+      rank: req.body?.rank || null,
+      status: req.body?.status || 'active',
+      is_verified: Boolean(req.body?.is_verified),
+      phone_verified: Boolean(req.body?.phone_verified),
+    };
+
+    const { data: officer, error } = await supabase
+      .from('users')
+      .insert([payload])
+      .select('*')
+      .single();
+
+    if (error || !officer) {
+      const message = error?.message || 'Unknown error';
+      if (message.toLowerCase().includes('duplicate')) {
+        throw new ConflictError('Officer with provided unique fields already exists');
+      }
+      throw new AppError(`Failed to create officer: ${message}`, 500);
+    }
+
+    return res.status(201).json({
+      success: true,
+      officer: mapOfficer(officer),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Update officer for admin
+ * PUT /api/admin/officers/:officerId
+ */
+export const updateOfficerAdmin = async (req, res, next) => {
+  try {
+    const { officerId } = req.params;
+    const updates = {};
+
+    if (req.body?.name !== undefined) {
+      const name = String(req.body.name || '').trim();
+      if (!name) throw new ValidationError('name cannot be empty');
+      updates.name = name;
+    }
+
+    if (req.body?.phone !== undefined) {
+      const phone = String(req.body.phone || '').trim();
+      if (!phone) throw new ValidationError('phone cannot be empty');
+      updates.phone = phone;
+    }
+
+    if (req.body?.email !== undefined) updates.email = req.body.email || null;
+    if (req.body?.badge_number !== undefined) updates.badge_number = req.body.badge_number || null;
+    if (req.body?.department !== undefined) updates.department = req.body.department || null;
+    if (req.body?.rank !== undefined) updates.rank = req.body.rank || null;
+    if (req.body?.status !== undefined) updates.status = req.body.status;
+    if (req.body?.is_verified !== undefined) updates.is_verified = Boolean(req.body.is_verified);
+    if (req.body?.phone_verified !== undefined) updates.phone_verified = Boolean(req.body.phone_verified);
+
+    if (Object.keys(updates).length === 0) {
+      throw new ValidationError('No fields provided to update');
+    }
+
+    const supabase = getSupabaseClient();
+
+    const { data: officer, error } = await supabase
+      .from('users')
+      .update(updates)
+      .eq('id', officerId)
+      .eq('role', 'police_officer')
+      .select('*')
+      .single();
+
+    if (error || !officer) {
+      const message = error?.message || 'Unknown error';
+      if (message.toLowerCase().includes('duplicate')) {
+        throw new ConflictError('Officer update violates unique constraints');
+      }
+      if (message.toLowerCase().includes('no rows')) {
+        throw new NotFoundError('Officer not found');
+      }
+      throw new AppError(`Failed to update officer: ${message}`, 500);
+    }
+
+    return res.status(200).json({
+      success: true,
+      officer: mapOfficer(officer),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Delete officer for admin
+ * DELETE /api/admin/officers/:officerId
+ */
+export const deleteOfficerAdmin = async (req, res, next) => {
+  try {
+    const { officerId } = req.params;
+    const supabase = getSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('users')
+      .delete()
+      .eq('id', officerId)
+      .eq('role', 'police_officer')
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      const message = error?.message || 'Unknown error';
+      if (message.toLowerCase().includes('foreign key')) {
+        throw new ConflictError('Cannot delete officer because related records exist');
+      }
+      if (message.toLowerCase().includes('no rows')) {
+        throw new NotFoundError('Officer not found');
+      }
+      throw new AppError(`Failed to delete officer: ${message}`, 500);
+    }
+
+    return res.status(200).json({
+      success: true,
+      id: officerId,
+      deleted: true,
     });
   } catch (error) {
     next(error);

--- a/backend/src/routes/adminOfficerRoutes.js
+++ b/backend/src/routes/adminOfficerRoutes.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import {
+  createOfficerAdmin,
+  deleteOfficerAdmin,
+  getAllOfficersAdmin,
+  getOfficerByIdAdmin,
+  updateOfficerAdmin,
+} from '../controllers/officerController.js';
+
+const router = express.Router();
+
+// GET /api/admin/officers
+router.get('/', getAllOfficersAdmin);
+
+// GET /api/admin/officers/:officerId
+router.get('/:officerId', getOfficerByIdAdmin);
+
+// POST /api/admin/officers
+router.post('/', createOfficerAdmin);
+
+// Backward-compatible create endpoint style
+router.post('/create', createOfficerAdmin);
+
+// PUT /api/admin/officers/:officerId
+router.put('/:officerId', updateOfficerAdmin);
+
+// Backward-compatible update endpoint style
+router.patch('/:officerId', updateOfficerAdmin);
+
+// DELETE /api/admin/officers/:officerId
+router.delete('/:officerId', deleteOfficerAdmin);
+
+export default router;

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -3,6 +3,7 @@ import { authenticate } from '../middlewares/authenticate.js';
 import { authorize } from '../middlewares/authorize.js';
 import adminFineRoutes from './adminFineRoutes.js';
 import adminDriverRoutes from './adminDriverRoutes.js';
+import adminOfficerRoutes from './adminOfficerRoutes.js';
 import { getAllCriminalsForAdmin } from '../controllers/criminalController.js';
 import { getAllNewsForAdmin, getDashboardStatsForAdmin } from '../controllers/adminController.js';
 
@@ -13,6 +14,7 @@ router.use(authorize('admin'));
 
 router.use('/fines', adminFineRoutes);
 router.use('/drivers', adminDriverRoutes);
+router.use('/officers', adminOfficerRoutes);
 router.get('/criminals', getAllCriminalsForAdmin);
 router.get('/news', getAllNewsForAdmin);
 router.get('/stats', getDashboardStatsForAdmin);


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added full CRUD functionality for admin officer routes, including creating, reading, updating, and deleting officers. The code changes include the creation of new functions such as getAllOfficersAdmin, getOfficerByIdAdmin, and createOfficerAdmin. These functions handle requests to fetch all officers, fetch an officer by ID, and create a new officer respectively.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-444](https://oshadadilshan.atlassian.net/browse/PEZY-444)

## Changes
- Added getAllOfficersAdmin function to fetch all officers
- Added getOfficerByIdAdmin function to fetch an officer by ID
- Added createOfficerAdmin function to create a new officer

[PEZY-444]: https://oshadadilshan.atlassian.net/browse/PEZY-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ