### PR TITLE
PEZY-554: Backend | News | Create public GET, admin news CRUD

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -69,6 +69,179 @@ export const getAllNewsForAdmin = async (req, res, next) => {
   }
 };
 
+const normalizeNewsPayload = (body) => ({
+  title: String(body.title || '').trim(),
+  content: String(body.content || '').trim(),
+  category: String(body.category || 'general').trim(),
+  featured: Boolean(body.featured),
+  pinned: Boolean(body.pinned),
+  published_at: body.publishedAt || body.published_at || null,
+});
+
+const mapNewsRow = (row, authorMap = {}) => {
+  const publishedAt = row.published_at || row.publishedAt || null;
+  const createdAt = row.created_at || row.createdAt || null;
+  const summary = row.summary || stripHtml(row.content).slice(0, 160);
+  const author = authorMap[row.author_id] || null;
+
+  return {
+    id: row.id,
+    title: row.title || 'Untitled',
+    content: row.content || '',
+    summary,
+    category: row.category || 'general',
+    status: row.status || (publishedAt ? 'published' : 'draft'),
+    featured: Boolean(row.featured),
+    pinned: Boolean(row.pinned),
+    publishedAt,
+    createdAt,
+    author: author ? author.name : row.authorName || row.author_id || 'Unknown Author',
+    authorEmail: author?.email || null,
+  };
+};
+
+export const createNewsForAdmin = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+    const { title, content, category, featured, pinned, published_at } = normalizeNewsPayload(req.body);
+    const status = String(req.body.status || 'draft').trim();
+
+    if (!title || !content) {
+      return res.status(400).json({
+        success: false,
+        message: 'Title and content are required',
+      });
+    }
+
+    const payload = {
+      title,
+      content,
+      category,
+      featured,
+      pinned,
+      author_id: req.user?.id || null,
+      published_at: status === 'published' ? (published_at || new Date().toISOString()) : published_at || null,
+    };
+
+    const { data: createdNews, error } = await supabase
+      .from('news')
+      .insert(payload)
+      .select('*')
+      .single();
+
+    if (error) {
+      return res.status(500).json({
+        success: false,
+        message: `Failed to create news: ${error.message}`,
+      });
+    }
+
+    return res.status(201).json({
+      success: true,
+      message: 'News created successfully',
+      news: mapNewsRow(createdNews),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateNewsForAdmin = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+    const { newsId } = req.params;
+    const { title, content, category, featured, pinned, published_at } = normalizeNewsPayload(req.body);
+    const status = String(req.body.status || 'draft').trim();
+
+    if (!newsId) {
+      return res.status(400).json({
+        success: false,
+        message: 'News ID is required',
+      });
+    }
+
+    const updatePayload = {
+      title,
+      content,
+      category,
+      featured,
+      pinned,
+      published_at: status === 'published' ? (published_at || new Date().toISOString()) : published_at || null,
+    };
+
+    const { data: updatedNews, error } = await supabase
+      .from('news')
+      .update(updatePayload)
+      .eq('id', newsId)
+      .select('*')
+      .single();
+
+    if (error) {
+      return res.status(500).json({
+        success: false,
+        message: `Failed to update news: ${error.message}`,
+      });
+    }
+
+    if (!updatedNews) {
+      return res.status(404).json({
+        success: false,
+        message: 'News article not found',
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: 'News updated successfully',
+      news: mapNewsRow(updatedNews),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const deleteNewsForAdmin = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+    const { newsId } = req.params;
+
+    if (!newsId) {
+      return res.status(400).json({
+        success: false,
+        message: 'News ID is required',
+      });
+    }
+
+    const { data: deletedNews, error } = await supabase
+      .from('news')
+      .delete()
+      .eq('id', newsId)
+      .select('id')
+      .single();
+
+    if (error) {
+      return res.status(500).json({
+        success: false,
+        message: `Failed to delete news: ${error.message}`,
+      });
+    }
+
+    if (!deletedNews) {
+      return res.status(404).json({
+        success: false,
+        message: 'News article not found',
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: 'News deleted successfully',
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
 export const getDashboardStatsForAdmin = async (req, res, next) => {
   try {
     const supabase = getSupabaseClient();

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -5,7 +5,13 @@ import adminFineRoutes from './adminFineRoutes.js';
 import adminDriverRoutes from './adminDriverRoutes.js';
 import adminOfficerRoutes from './adminOfficerRoutes.js';
 import { getAllCriminalsForAdmin } from '../controllers/criminalController.js';
-import { getAllNewsForAdmin, getDashboardStatsForAdmin } from '../controllers/adminController.js';
+import {
+	createNewsForAdmin,
+	deleteNewsForAdmin,
+	getAllNewsForAdmin,
+	getDashboardStatsForAdmin,
+	updateNewsForAdmin,
+} from '../controllers/adminController.js';
 
 const router = express.Router();
 
@@ -17,6 +23,9 @@ router.use('/drivers', adminDriverRoutes);
 router.use('/officers', adminOfficerRoutes);
 router.get('/criminals', getAllCriminalsForAdmin);
 router.get('/news', getAllNewsForAdmin);
+router.post('/news', createNewsForAdmin);
+router.put('/news/:newsId', updateNewsForAdmin);
+router.delete('/news/:newsId', deleteNewsForAdmin);
 router.get('/stats', getDashboardStatsForAdmin);
 
 export default router;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -88,6 +88,28 @@ export const adminAPI = {
 
   getAllCriminals: () => axiosInstance.get('/admin/criminals'),
 
+  createNews: (payload: {
+    title: string
+    content: string
+    category?: string
+    featured?: boolean
+    pinned?: boolean
+    status?: 'draft' | 'scheduled' | 'published'
+    publishedAt?: string | null
+  }) => axiosInstance.post('/admin/news', payload),
+
+  updateNews: (newsId: string, payload: {
+    title?: string
+    content?: string
+    category?: string
+    featured?: boolean
+    pinned?: boolean
+    status?: 'draft' | 'scheduled' | 'published'
+    publishedAt?: string | null
+  }) => axiosInstance.put(`/admin/news/${newsId}`, payload),
+
+  deleteNews: (newsId: string) => axiosInstance.delete(`/admin/news/${newsId}`),
+
   getAllOfficers: () => axiosInstance.get('/admin/officers'),
 
   createOfficer: (payload: {

--- a/frontend/src/pages/AdminNewsManagement.css
+++ b/frontend/src/pages/AdminNewsManagement.css
@@ -319,6 +319,21 @@
   background: #eff3f8;
 }
 
+.admin-news__action-btn--edit:hover {
+  background: #dbeafe;
+  color: #0284c7;
+}
+
+.admin-news__action-btn--delete:hover {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.admin-news__action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .admin-news__action-btn svg {
   width: 18px;
   height: 18px;
@@ -419,6 +434,26 @@
 .admin-news__modal-form label {
   display: grid;
   gap: 6px;
+}
+
+.admin-news__modal-flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.admin-news__check-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #334155;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.admin-news__check-item input {
+  width: 16px;
+  height: 16px;
 }
 
 .admin-news__modal-form label span {

--- a/frontend/src/pages/AdminNewsManagementLive.tsx
+++ b/frontend/src/pages/AdminNewsManagementLive.tsx
@@ -7,9 +7,11 @@ type ArticleStatus = 'published' | 'draft' | 'scheduled'
 interface NewsArticle {
   id: string
   title: string
+  content: string
   summary: string
   author: string
   date: string
+  publishedAt: string
   status: ArticleStatus
   category: string
   featured: boolean
@@ -24,6 +26,26 @@ const statusLabel: Record<ArticleStatus, string> = {
 }
 
 type StatusFilter = 'all' | ArticleStatus
+
+interface NewsFormValues {
+  title: string
+  content: string
+  category: string
+  status: ArticleStatus
+  featured: boolean
+  pinned: boolean
+  publishedAt: string
+}
+
+const initialFormValues: NewsFormValues = {
+  title: '',
+  content: '',
+  category: 'general',
+  status: 'draft',
+  featured: false,
+  pinned: false,
+  publishedAt: '',
+}
 
 const formatDate = (value: string) => {
   if (!value) return '-'
@@ -41,6 +63,12 @@ export default function AdminNewsManagementLive() {
   const [isFilterMenuOpen, setIsFilterMenuOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [editingNewsId, setEditingNewsId] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isDeletingId, setIsDeletingId] = useState<string | null>(null)
+  const [formValues, setFormValues] = useState<NewsFormValues>(initialFormValues)
+  const [formError, setFormError] = useState<string | null>(null)
 
   const fetchNews = async () => {
     try {
@@ -52,8 +80,8 @@ export default function AdminNewsManagementLive() {
         news?: Array<{
           id: string
           title?: string
-          summary?: string
           content?: string
+          summary?: string
           author?: string
           publishedAt?: string | null
           createdAt?: string | null
@@ -72,8 +100,10 @@ export default function AdminNewsManagementLive() {
         return {
           id: article.id,
           title: article.title || 'Untitled',
+          content: article.content || article.summary || '',
           summary: summary.length > 140 ? `${summary.slice(0, 140).trim()}...` : summary,
           author: article.author || 'Unknown Author',
+          publishedAt: rawDate,
           date: formatDate(rawDate),
           status: (article.status as ArticleStatus) || (article.publishedAt ? 'published' : 'draft'),
           category: article.category || 'general',
@@ -136,6 +166,94 @@ export default function AdminNewsManagementLive() {
     setIsFilterMenuOpen(false)
   }
 
+  const openAddModal = () => {
+    setEditingNewsId(null)
+    setFormValues(initialFormValues)
+    setFormError(null)
+    setIsModalOpen(true)
+  }
+
+  const openEditModal = (article: NewsArticle) => {
+    setEditingNewsId(article.id)
+    setFormValues({
+      title: article.title,
+      content: article.content,
+      category: article.category,
+      status: article.status,
+      featured: article.featured,
+      pinned: article.pinned,
+        publishedAt: article.publishedAt ? article.publishedAt.slice(0, 16) : '',
+    })
+    setFormError(null)
+    setIsModalOpen(true)
+  }
+
+  const closeModal = () => {
+    if (isSaving) return
+    setIsModalOpen(false)
+    setEditingNewsId(null)
+  }
+
+  const updateForm = <K extends keyof NewsFormValues>(field: K, value: NewsFormValues[K]) => {
+    setFormValues(previous => ({ ...previous, [field]: value }))
+    if (formError) setFormError(null)
+  }
+
+  const handleSaveNews = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!formValues.title.trim() || !formValues.content.trim()) {
+      setFormError('Title and content are required.')
+      return
+    }
+
+    try {
+      setIsSaving(true)
+      setFormError(null)
+
+      const payload = {
+        title: formValues.title.trim(),
+        content: formValues.content.trim(),
+        category: formValues.category.trim() || 'general',
+        status: formValues.status,
+        featured: formValues.featured,
+        pinned: formValues.pinned,
+        publishedAt: formValues.publishedAt ? new Date(formValues.publishedAt).toISOString() : null,
+      }
+
+      if (editingNewsId) {
+        await adminAPI.updateNews(editingNewsId, payload)
+      } else {
+        await adminAPI.createNews(payload)
+      }
+
+      await fetchNews()
+      setIsModalOpen(false)
+      setEditingNewsId(null)
+    } catch (error) {
+      console.error('Failed to save news:', error)
+      setFormError(editingNewsId ? 'Unable to update news right now. Please try again.' : 'Unable to create news right now. Please try again.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleDeleteNews = async (article: NewsArticle) => {
+    const confirmed = window.confirm(`Delete news article \"${article.title}\"? This action cannot be undone.`)
+    if (!confirmed) return
+
+    try {
+      setIsDeletingId(article.id)
+      await adminAPI.deleteNews(article.id)
+      await fetchNews()
+    } catch (error) {
+      console.error('Failed to delete news:', error)
+      window.alert('Unable to delete news right now. Please try again.')
+    } finally {
+      setIsDeletingId(null)
+    }
+  }
+
   return (
     <section className="admin-news" aria-label="News management page">
       <header className="admin-news__header">
@@ -144,11 +262,11 @@ export default function AdminNewsManagementLive() {
           <p>Fetched live from GET /api/admin/news</p>
         </div>
 
-        <button type="button" className="admin-news__add-btn" onClick={fetchNews}>
+        <button type="button" className="admin-news__add-btn" onClick={openAddModal}>
           <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M11 5h2v14h-2V5Zm-6 6h14v2H5v-2Z" fill="currentColor" />
           </svg>
-          <span>Refresh</span>
+          <span>Add</span>
         </button>
       </header>
 
@@ -260,6 +378,19 @@ export default function AdminNewsManagementLive() {
                     <span>{article.views ?? 0}</span>
                     <small>Views</small>
                   </div>
+
+                    <div className="admin-news__actions">
+                      <button type="button" className="admin-news__action-btn admin-news__action-btn--edit" onClick={() => openEditModal(article)} aria-label={`Edit ${article.title}`}>
+                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                          <path d="M3 17.25V21h3.75L17.8 9.95l-3.75-3.75L3 17.25Zm14.71-9.04a1 1 0 0 0 0-1.41l-1.5-1.5a1 1 0 0 0-1.41 0l-1.12 1.12 3.75 3.75 1.28-1.96Z" fill="currentColor" />
+                        </svg>
+                      </button>
+                      <button type="button" className="admin-news__action-btn admin-news__action-btn--delete" onClick={() => handleDeleteNews(article)} aria-label={`Delete ${article.title}`} disabled={isDeletingId === article.id}>
+                        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                          <path d="M6 7h12v2H6V7Zm2 3h8l-.67 9.33A2 2 0 0 1 13.34 21H10.66a2 2 0 0 1-1.99-1.67L8 10Zm3-6h2l1 1h4v2H4V5h4l1-1Z" fill="currentColor" />
+                        </svg>
+                      </button>
+                    </div>
                 </div>
               </article>
             ))
@@ -291,6 +422,86 @@ export default function AdminNewsManagementLive() {
           <strong>{totalViews.toLocaleString('en-LK')}</strong>
         </article>
       </section>
+
+      {isModalOpen ? (
+        <div className="admin-news__modal-overlay" role="dialog" aria-modal="true" aria-labelledby="admin-news-modal-title">
+          <div className="admin-news__modal">
+            <div className="admin-news__modal-header">
+              <h3 id="admin-news-modal-title">{editingNewsId ? 'Edit News Article' : 'Add News Article'}</h3>
+              <button type="button" className="admin-news__modal-close" onClick={closeModal} aria-label="Close">
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M6 6 18 18M18 6 6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+
+            <form className="admin-news__modal-form" onSubmit={handleSaveNews}>
+              <label>
+                <span>Title</span>
+                <input type="text" value={formValues.title} onChange={event => updateForm('title', event.target.value)} />
+              </label>
+
+              <label>
+                <span>Content</span>
+                <textarea value={formValues.content} onChange={event => updateForm('content', event.target.value)} />
+              </label>
+
+              <div className="admin-news__modal-grid">
+                <label>
+                  <span>Category</span>
+                  <input type="text" value={formValues.category} onChange={event => updateForm('category', event.target.value)} />
+                </label>
+
+                <label>
+                  <span>Status</span>
+                  <select value={formValues.status} onChange={event => updateForm('status', event.target.value as ArticleStatus)}>
+                    <option value="draft">Draft</option>
+                    <option value="scheduled">Scheduled</option>
+                    <option value="published">Published</option>
+                  </select>
+                </label>
+
+                <label>
+                  <span>Published At</span>
+                  <input type="datetime-local" value={formValues.publishedAt} onChange={event => updateForm('publishedAt', event.target.value)} />
+                </label>
+
+                <label>
+                  <span>Flags</span>
+                  <div className="admin-news__modal-flags">
+                    <label className="admin-news__check-item">
+                      <input type="checkbox" checked={formValues.featured} onChange={event => updateForm('featured', event.target.checked)} />
+                      <span>Featured</span>
+                    </label>
+                    <label className="admin-news__check-item">
+                      <input type="checkbox" checked={formValues.pinned} onChange={event => updateForm('pinned', event.target.checked)} />
+                      <span>Pinned</span>
+                    </label>
+                  </div>
+                </label>
+              </div>
+
+              <div className="admin-news__modal-flags">
+                <label className="admin-news__check-item">
+                  <input type="checkbox" checked={formValues.featured} onChange={event => updateForm('featured', event.target.checked)} />
+                  <span>Featured</span>
+                </label>
+                <label className="admin-news__check-item">
+                  <input type="checkbox" checked={formValues.pinned} onChange={event => updateForm('pinned', event.target.checked)} />
+                  <span>Pinned</span>
+                </label>
+              </div>
+
+              {formError ? <small>{formError}</small> : null}
+
+              <div className="admin-news__modal-actions">
+                <button type="button" className="admin-news__modal-btn is-muted" onClick={closeModal} disabled={isSaving}>Cancel</button>
+                <button type="submit" className="admin-news__modal-btn is-primary" disabled={isSaving}>{isSaving ? 'Saving...' : (editingNewsId ? 'Update News' : 'Create News')}</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
     </section>
   )
 }


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added admin news CRUD operations and a function to normalize news payload. The createNewsForAdmin function now inserts news into the database and returns the created news in a formatted manner.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-554](https://oshadadilshan.atlassian.net/browse/PEZY-554)

## Changes
- Added normalizeNewsPayload function to format news payload
- Added createNewsForAdmin function to create news for admins
- Added updateNewsForAdmin function to update news for admins
- Added mapNewsRow function to format news row data

[PEZY-554]: https://oshadadilshan.atlassian.net/browse/PEZY-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ