### PR TITLE
PEZY-559: Create public getAllCriminals() and getCriminalsID()

### DIFF
--- a/backend/src/controllers/criminalController.js
+++ b/backend/src/controllers/criminalController.js
@@ -1,4 +1,4 @@
-import { createCriminal, updateCriminal, getAllCriminals, deleteCriminal, getCriminalById } from '../services/criminalService.js';
+import { createCriminal, updateCriminal, getAllCriminals, deleteCriminal, getCriminalById, getAllCriminalsPublic as getAllCriminalsPublicService, getCriminalByIdPublic as getCriminalByIdPublicService } from '../services/criminalService.js';
 import { deletePhotoFile } from '../middlewares/uploadPhoto.js';
 
 /**
@@ -204,6 +204,68 @@ export const uploadCriminalPhotoRecord = async (req, res, next) => {
     if (req.file) {
       deletePhotoFile(`/uploads/criminals/${req.file.filename}`);
     }
+    next(error);
+  }
+};
+
+/**
+ * Get all active/wanted criminals (public view)
+ * GET /api/criminals
+ * Query parameters:
+ *   - limit: number (default: 20, max: 100)
+ *   - offset: number (default: 0)
+ *   - wanted: boolean (filter by wanted status)
+ *   - search: string (search in first_name/last_name)
+ * Returns: { success, criminals: Array, total, limit, offset }
+ * Public Access: YES
+ */
+export const getAllCriminalsPublic = async (req, res, next) => {
+  try {
+    const queryOptions = {
+      limit: req.query.limit ? parseInt(req.query.limit) : undefined,
+      offset: req.query.offset ? parseInt(req.query.offset) : undefined,
+      wanted: req.query.wanted === 'true' ? true : undefined,
+      search: req.query.search,
+    };
+
+    // Remove undefined values
+    Object.keys(queryOptions).forEach((key) => queryOptions[key] === undefined && delete queryOptions[key]);
+
+    const result = await getAllCriminalsPublicService(queryOptions);
+
+    return res.status(200).json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * Get a single criminal by ID (public view)
+ * GET /api/criminals/:id
+ * Returns: { success, criminal }
+ * Public Access: YES
+ */
+export const getCriminalByIdPublic = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        message: 'Criminal ID is required',
+      });
+    }
+
+    const criminal = await getCriminalByIdPublicService(id);
+
+    return res.status(200).json({
+      success: true,
+      criminal,
+    });
+  } catch (error) {
     next(error);
   }
 };

--- a/backend/src/routes/criminalRoutes.js
+++ b/backend/src/routes/criminalRoutes.js
@@ -2,21 +2,43 @@ import express from 'express';
 import { authenticate } from '../middlewares/authenticate.js';
 import { authorize } from '../middlewares/authorize.js';
 import { uploadCriminalPhoto } from '../middlewares/uploadPhoto.js';
-import { createCriminalRecord, updateCriminalRecord, getAllCriminalsRecords, deleteCriminalRecord, getCriminalRecord, uploadCriminalPhotoRecord } from '../controllers/criminalController.js';
+import { createCriminalRecord, updateCriminalRecord, getAllCriminalsRecords, deleteCriminalRecord, getCriminalRecord, uploadCriminalPhotoRecord, getAllCriminalsPublic, getCriminalByIdPublic } from '../controllers/criminalController.js';
 
 const router = express.Router();
 
 /**
- * Criminal Management Routes
+ * CRIMINAL ROUTES - Combined Public & Police Officer/Admin
  * Base: /api/criminals
  */
 
+// ============================================================
+// PUBLIC CRIMINAL ROUTES - No Authentication Required
+// ============================================================
+
 /**
  * GET /api/criminals
- * Get all criminals with optional filtering and pagination
- * Protected: requires police_officer role
+ * Get all active/wanted criminals (public view)
+ * Query parameters:
+ *   - limit: number (default: 20, max: 100)
+ *   - offset: number (default: 0)
+ *   - wanted: boolean (filter by wanted status)
+ *   - search: string (search in first_name/last_name)
+ * Returns: { success, criminals: Array, total, limit, offset }
+ * Public Access: YES
  */
-router.get('/', authenticate, authorize('police_officer'), getAllCriminalsRecords);
+router.get('/', getAllCriminalsPublic);
+
+/**
+ * GET /api/criminals/:id
+ * Get a single criminal by ID (public view)
+ * Returns: { success, criminal }
+ * Public Access: YES
+ */
+router.get('/:id', getCriminalByIdPublic);
+
+// ============================================================
+// PROTECTED CRIMINAL ROUTES - Police Officer Authentication
+// ============================================================
 
 /**
  * POST /api/criminals/create
@@ -37,13 +59,6 @@ router.post('/:id/photo',
   uploadCriminalPhoto.single('photo'),
   uploadCriminalPhotoRecord
 );
-
-/**
- * GET /api/criminals/:id
- * Get a criminal record by ID
- * Protected: requires police_officer role
- */
-router.get('/:id', authenticate, authorize('police_officer'), getCriminalRecord);
 
 /**
  * PATCH /api/criminals/:id

--- a/backend/src/services/criminalService.js
+++ b/backend/src/services/criminalService.js
@@ -378,3 +378,120 @@ export const deleteCriminal = async (criminalId) => {
     criminal_id: criminalId,
   };
 };
+
+/**
+ * Get all active criminals (public view)
+ * Only returns non-deleted, active/wanted criminals
+ * @param {Object} options - Query options
+ * @param {number} options.limit - Limit results (default: 20, max: 100)
+ * @param {number} options.offset - Offset for pagination (default: 0)
+ * @param {boolean} options.wanted - Filter by wanted status (optional)
+ * @param {string} options.search - Search in first_name or last_name (optional)
+ * @returns {Promise<Object>} { criminals: Array, total: number, limit, offset }
+ */
+export const getAllCriminalsPublic = async (options = {}) => {
+  const supabase = getSupabaseClient();
+
+  // Validate and set defaults
+  let limit = options.limit || 20;
+  if (limit > 100) limit = 100;
+  if (limit < 1) limit = 1;
+
+  const offset = options.offset || 0;
+  if (offset < 0) {
+    throw new ValidationError('Offset cannot be negative');
+  }
+
+  let query = supabase.from('criminals').select('*', { count: 'exact' });
+
+  // Only show active and wanted criminals that are not deleted
+  query = query.is('deleted_at', null);
+  query = query.neq('status', 'inactive');
+
+  // Filter by wanted status if provided
+  if (options.wanted === true) {
+    query = query.eq('wanted', true);
+  }
+
+  // Search in first_name or last_name
+  if (options.search) {
+    const searchTerm = `%${options.search}%`;
+    query = query.or(`first_name.ilike.${searchTerm},last_name.ilike.${searchTerm}`);
+  }
+
+  // Order by wanted status first, then by created_at
+  const { data: criminals, error, count } = await query
+    .order('wanted', { ascending: false })
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    throw new Error(`Failed to fetch criminals: ${error.message}`);
+  }
+
+  return {
+    criminals: (criminals || []).map((criminal) => ({
+      id: criminal.id,
+      firstName: criminal.first_name,
+      lastName: criminal.last_name,
+      status: criminal.status,
+      wanted: criminal.wanted,
+      dangerLevel: criminal.danger_level,
+      gender: criminal.gender,
+      dateOfBirth: criminal.date_of_birth,
+      description: criminal.physical_description,
+      photoUrl: criminal.photo_path,
+      arrestCount: criminal.arrest_count,
+    })),
+    total: count || 0,
+    limit,
+    offset,
+  };
+};
+
+/**
+ * Get a single criminal by ID (public view)
+ * Only returns non-deleted criminals
+ * @param {string} criminalId - Criminal ID (UUID)
+ * @returns {Promise<Object>} Criminal record
+ * @throws {ValidationError} If ID is missing
+ * @throws {NotFoundError} If criminal not found or deleted
+ */
+export const getCriminalByIdPublic = async (criminalId) => {
+  if (!criminalId) {
+    throw new ValidationError('Criminal ID is required');
+  }
+
+  const supabase = getSupabaseClient();
+
+  // Get non-deleted criminal only
+  const { data: criminal, error } = await supabase
+    .from('criminals')
+    .select('*')
+    .eq('id', criminalId)
+    .is('deleted_at', null)
+    .single();
+
+  if (error || !criminal) {
+    throw new NotFoundError('Criminal record not found');
+  }
+
+  return {
+    id: criminal.id,
+    firstName: criminal.first_name,
+    lastName: criminal.last_name,
+    dateOfBirth: criminal.date_of_birth,
+    gender: criminal.gender,
+    status: criminal.status,
+    wanted: criminal.wanted,
+    dangerLevel: criminal.danger_level,
+    description: criminal.physical_description,
+    identificationNumber: criminal.identification_number,
+    knownAliases: criminal.known_aliases,
+    arrestedBefore: criminal.arrested_before,
+    arrestCount: criminal.arrest_count,
+    photoUrl: criminal.photo_path,
+    photoUploadedAt: criminal.photo_uploaded_at,
+    createdAt: criminal.created_at,
+  };
+};


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added two new public API endpoints, `getAllCriminalsPublic` and `getCriminalByIdPublic`, to retrieve criminal data. The `getAllCriminalsPublic` endpoint returns a list of active/wanted criminals with optional filtering and pagination, while the `getCriminalByIdPublic` endpoint returns a single criminal by ID. These endpoints are designed for public access.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-559](https://oshadadilshan.atlassian.net/browse/PEZY-559)

## Changes
- Added `getAllCriminalsPublic` endpoint to retrieve a list of active/wanted criminals
- Added `getCriminalByIdPublic` endpoint to retrieve a single criminal by ID
- Updated `criminalController.js` to include the new endpoints
- Updated `criminalRoutes.js` to include routes for the new endpoints

[PEZY-559]: https://oshadadilshan.atlassian.net/browse/PEZY-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ