### PR TITLE
PEZY-426: Validate PayHere Webhook Signature

### DIFF
--- a/backend/src/middlewares/validatePayHereWebhookSignature.js
+++ b/backend/src/middlewares/validatePayHereWebhookSignature.js
@@ -1,0 +1,67 @@
+import crypto from 'crypto';
+
+const generateExpectedSignature = (merchantId, orderId, amount, currency, statusCode) => {
+  const merchantSecret = process.env.PAYHERE_MERCHANT_SECRET;
+
+  const hashedSecret = crypto
+    .createHash('md5')
+    .update(merchantSecret)
+    .digest('hex')
+    .toUpperCase();
+
+  return crypto
+    .createHash('md5')
+    .update(`${merchantId}${orderId}${amount}${currency}${statusCode}${hashedSecret}`)
+    .digest('hex')
+    .toUpperCase();
+};
+
+export const validatePayHereWebhookSignature = (req, res, next) => {
+  try {
+    const {
+      merchant_id: merchantId,
+      order_id: orderId,
+      payhere_amount: amount,
+      payhere_currency: currency,
+      status_code: statusCode,
+      md5sig,
+    } = req.body || {};
+
+    if (!merchantId || !orderId || !amount || !currency || statusCode === undefined || !md5sig) {
+      return res.status(400).json({
+        success: false,
+        message: 'Missing required PayHere webhook fields',
+      });
+    }
+
+    if (!process.env.PAYHERE_MERCHANT_SECRET) {
+      return res.status(500).json({
+        success: false,
+        message: 'PAYHERE_MERCHANT_SECRET is not configured',
+      });
+    }
+
+    const expectedSignature = generateExpectedSignature(
+      merchantId,
+      orderId,
+      amount,
+      currency,
+      statusCode
+    );
+
+    if (expectedSignature !== md5sig) {
+      return res.status(400).json({
+        success: false,
+        message: 'Invalid PayHere notification signature',
+      });
+    }
+
+    return next();
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: 'Failed to validate PayHere webhook signature',
+      error: error.message,
+    });
+  }
+};

--- a/backend/src/routes/paymentRoutes.js
+++ b/backend/src/routes/paymentRoutes.js
@@ -3,6 +3,7 @@ import {
   handlePaymentWebhookHandler,
   initiatePaymentHandler,
 } from '../controllers/paymentController.js';
+import { validatePayHereWebhookSignature } from '../middlewares/validatePayHereWebhookSignature.js';
 
 const router = express.Router();
 
@@ -12,6 +13,6 @@ const router = express.Router();
  * Returns: PayHere checkout parameters for the frontend.
  */
 router.post('/initiate', initiatePaymentHandler);
-router.post('/webhook', handlePaymentWebhookHandler);
+router.post('/webhook', validatePayHereWebhookSignature, handlePaymentWebhookHandler);
 
 export default router;

--- a/backend/src/services/paymentService.js
+++ b/backend/src/services/paymentService.js
@@ -26,27 +26,6 @@ const generatePayHereHash = (orderId, amount, currency) => {
   return hash;
 };
 
-/**
- * Generate the expected PayHere webhook signature.
- * Formula from PayHere notify_url docs:
- * MD5(merchant_id + order_id + payhere_amount + payhere_currency + status_code + MD5(merchant_secret).toUpperCase()).toUpperCase()
- */
-const generatePayHereNotifySignature = (merchantId, orderId, amount, currency, statusCode) => {
-  const merchantSecret = process.env.PAYHERE_MERCHANT_SECRET;
-
-  const hashedSecret = crypto
-    .createHash('md5')
-    .update(merchantSecret)
-    .digest('hex')
-    .toUpperCase();
-
-  return crypto
-    .createHash('md5')
-    .update(`${merchantId}${orderId}${amount}${currency}${statusCode}${hashedSecret}`)
-    .digest('hex')
-    .toUpperCase();
-};
-
 const createPendingPaymentRecords = async (supabase, orderId, fines) => {
   const paymentRows = fines.map((fine) => ({
     fine_id: fine.id,
@@ -241,36 +220,17 @@ export const initiatePayment = async (fineIds, licenseNo) => {
  */
 export const handleWebhook = async (payload) => {
   const {
-    merchant_id: merchantId,
     order_id: orderId,
     payment_id: paymentId,
-    payhere_amount: amount,
-    payhere_currency: currency,
     status_code: statusCode,
-    md5sig,
     custom_1: customFineIds,
     custom_2: licenseNo,
   } = payload || {};
 
-  if (!merchantId || !orderId || !amount || !currency || statusCode === undefined || !md5sig) {
+  if (!orderId || statusCode === undefined) {
     throw {
       status: 400,
       message: 'Missing required PayHere webhook fields',
-    };
-  }
-
-  const expectedSignature = generatePayHereNotifySignature(
-    merchantId,
-    orderId,
-    amount,
-    currency,
-    statusCode
-  );
-
-  if (expectedSignature !== md5sig) {
-    throw {
-      status: 400,
-      message: 'Invalid PayHere notification signature',
     };
   }
 


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Added a middleware to validate the PayHere webhook signature by computing the expected hash from payload fields and comparing it with the received hash. If the hashes do not match, the request is rejected with a 400 status code. This ensures the integrity of the webhook notifications.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-426](https://oshadadilshan.atlassian.net/browse/PEZY-426)

## Changes
- Created a new middleware function `validatePayHereWebhookSignature` to validate the PayHere webhook signature
- Added the middleware to the `/webhook` route in `paymentRoutes.js`
- Updated `paymentRoutes.js` to import and use the new middleware function

[PEZY-426]: https://oshadadilshan.atlassian.net/browse/PEZY-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ