### PR TITLE
PEZY-359: Implement GET /api/fines/outdated API call

### DIFF
--- a/mobile/pezy_mobile/lib/features/fine/data/services/fine_api_service.dart
+++ b/mobile/pezy_mobile/lib/features/fine/data/services/fine_api_service.dart
@@ -291,4 +291,57 @@ class FineApiService {
       rethrow;
     }
   }
+
+  /// Fetch outdated fines list
+  /// GET /api/fines/outdated
+  /// Returns list of fines that are past their due date and unpaid
+  Future<List<FineInfo>> getOutdatedFines() async {
+    try {
+      debugPrint('\n╔════════════════════════════════════════╗');
+      debugPrint('║  FINE API: GET OUTDATED FINES          ║');
+      debugPrint('╚════════════════════════════════════════╝\n');
+
+      final response = await _dio.get('/fines/outdated');
+
+      debugPrint('✅ Outdated fines fetched successfully');
+      debugPrint('Status Code: ${response.statusCode}');
+      debugPrint('Response: ${response.data}\n');
+
+      if (response.statusCode == 200) {
+        // Response should be a list of fines directly
+        if (response.data is Map && response.data.containsKey('fines')) {
+          // If wrapped in object
+          final finesList = (response.data['fines'] as List?)
+              ?.map((f) => FineInfo.fromJson(f))
+              .toList() ?? [];
+          return finesList;
+        } else if (response.data is List) {
+          // If response is directly a list
+          return (response.data as List)
+              .map((f) => FineInfo.fromJson(f))
+              .toList();
+        }
+        return [];
+      } else {
+        throw Exception('Failed to fetch outdated fines. Status: ${response.statusCode}');
+      }
+    } on DioException catch (e) {
+      debugPrint('❌ Get outdated fines error: ${e.message}');
+      debugPrint('Status Code: ${e.response?.statusCode}');
+      debugPrint('Response: ${e.response?.data}\n');
+
+      if (e.response?.statusCode == 401) {
+        throw Exception('Unauthorized. Please login again.');
+      } else if (e.type == DioExceptionType.connectionTimeout) {
+        throw Exception('Connection timeout - please check your internet connection');
+      } else if (e.type == DioExceptionType.receiveTimeout) {
+        throw Exception('Request timeout - please try again');
+      } else {
+        throw Exception('Error: ${e.message}');
+      }
+    } catch (e) {
+      debugPrint('❌ Unexpected error: $e\n');
+      rethrow;
+    }
+  }
 }

--- a/mobile/pezy_mobile/lib/features/fine/presentation/pages/outdated_fines_screen.dart
+++ b/mobile/pezy_mobile/lib/features/fine/presentation/pages/outdated_fines_screen.dart
@@ -130,6 +130,40 @@ class _OutdatedFinesScreenState extends ConsumerState<OutdatedFinesScreen>
                   ),
                 ),
               )
+            else if (finesState.errorMessage != null && finesState.errorMessage!.isNotEmpty)
+              SliverFillRemaining(
+                child: Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        size: 64,
+                        color: AppColors.error.withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(height: AppSpacing.lg),
+                      Text(
+                        'Error loading fines',
+                        style: AppTextStyles.bodyMedium.copyWith(
+                          color: AppColors.textSecondary,
+                          fontSize: 16,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+                        child: Text(
+                          finesState.errorMessage!,
+                          textAlign: TextAlign.center,
+                          style: AppTextStyles.bodySmall.copyWith(
+                            color: AppColors.error,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              )
             else if (finesState.fines.isEmpty)
               SliverFillRemaining(
                 child: Center(

--- a/mobile/pezy_mobile/lib/features/fine/presentation/providers/outdated_fines_provider.dart
+++ b/mobile/pezy_mobile/lib/features/fine/presentation/providers/outdated_fines_provider.dart
@@ -1,4 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+import '../../data/services/fine_api_service.dart';
+import '../../../auth/presentation/providers/auth_provider.dart';
 
 /// Model for a single outdated fine
 class OutdatedFine {
@@ -41,7 +44,9 @@ class OutdatedFinesState {
 
 /// Notifier for managing outdated fines state
 class OutdatedFinesNotifier extends StateNotifier<OutdatedFinesState> {
-  OutdatedFinesNotifier() : super(const OutdatedFinesState()) {
+  final Dio _dio;
+
+  OutdatedFinesNotifier(this._dio) : super(const OutdatedFinesState()) {
     // Load fines on initialization
     loadOutdatedFines();
   }
@@ -51,63 +56,42 @@ class OutdatedFinesNotifier extends StateNotifier<OutdatedFinesState> {
     state = state.copyWith(isLoading: true, errorMessage: null);
 
     try {
-      // Simulate API call to fetch outdated fines
-      await Future.delayed(const Duration(seconds: 1));
+      print('\n╔════════════════════════════════════════╗');
+      print('║  OUTDATED FINES PROVIDER: LOAD         ║');
+      print('╚════════════════════════════════════════╝\n');
 
-      // Mock data for outdated fines
-      final mockFines = _getMockOutdatedFines();
+      // Use the authenticated Dio instance
+      final apiService = FineApiService(dio: _dio);
+      final finesList = await apiService.getOutdatedFines();
+
+      print('✅ Loaded ${finesList.length} outdated fines');
+
+      // Convert FineInfo to OutdatedFine
+      final outdatedFines = finesList.map((fine) {
+        return OutdatedFine(
+          licenseNo: fine.licenseNumber,
+          driverName: fine.driverName,
+          amount: fine.amount,
+        );
+      }).toList();
 
       state = state.copyWith(
-        fines: mockFines,
+        fines: outdatedFines,
         isLoading: false,
       );
     } catch (e) {
+      print('❌ Error loading outdated fines: $e\n');
       state = state.copyWith(
         isLoading: false,
-        errorMessage: 'Error loading outdated fines: ${e.toString()}',
+        errorMessage: 'Error loading outdated fines: ${e.toString().replaceAll('Exception: ', '')}',
       );
     }
-  }
-
-  /// Mock data for testing - replace with actual API call
-  List<OutdatedFine> _getMockOutdatedFines() {
-    return [
-      OutdatedFine(
-        licenseNo: 'DL0001',
-        driverName: 'John Doe',
-        amount: 5000.0,
-      ),
-      OutdatedFine(
-        licenseNo: 'DL0002',
-        driverName: 'Jane Smith',
-        amount: 7500.0,
-      ),
-      OutdatedFine(
-        licenseNo: 'DL0003',
-        driverName: 'Robert Johnson',
-        amount: 3200.0,
-      ),
-      OutdatedFine(
-        licenseNo: 'DL0004',
-        driverName: 'Emily Williams',
-        amount: 6800.0,
-      ),
-      OutdatedFine(
-        licenseNo: 'DL0005',
-        driverName: 'Michael Brown',
-        amount: 4500.0,
-      ),
-      OutdatedFine(
-        licenseNo: 'DL0006',
-        driverName: 'Sarah Davis',
-        amount: 8200.0,
-      ),
-    ];
   }
 }
 
 /// Riverpod provider for outdated fines state
 final outdatedFinesProvider =
     StateNotifierProvider<OutdatedFinesNotifier, OutdatedFinesState>((ref) {
-  return OutdatedFinesNotifier();
+  final authenticatedDio = ref.watch(authenticatedDioProvider);
+  return OutdatedFinesNotifier(authenticatedDio);
 });

--- a/testOutdatedFines.js
+++ b/testOutdatedFines.js
@@ -1,0 +1,23 @@
+import fetch from 'node-fetch';
+
+// Test with a sample token (this will likely fail without auth)
+// But first, let's try to get a token or use public endpoint
+const testOutdatedFines = async () => {
+  try {
+    // Try without token first
+    const response = await fetch('http://localhost:8000/api/fines/outdated', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    });
+
+    const data = await response.json();
+    console.log('Status:', response.status);
+    console.log('Response:', JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+};
+
+testOutdatedFines();


### PR DESCRIPTION
<!-- AI-GENERATED-PR-DESCRIPTION -->
## Description
Implemented the GET /api/fines/outdated API call to fetch outdated fines list. The `getOutdatedFines` function in `FineApiService` handles the API call and returns a list of fines that are past their due date and unpaid. It also includes error handling for cases like connection timeout, receive timeout, and unauthorized access.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other

## Jira Reference
- Issue: [PEZY-359](https://oshadadilshan.atlassian.net/browse/PEZY-359)

## Changes
- Added `getOutdatedFines` function to `FineApiService` to handle the GET /api/fines/outdated API call
- Implemented error handling for the API call
- Updated `OutdatedFinesScreen` to fetch outdated fines list on screen load and display a loading indicator

[PEZY-359]: https://oshadadilshan.atlassian.net/browse/PEZY-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ